### PR TITLE
chore(readme): rename cloud to platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Camunda Cloud Tutorials
+# Camunda Platform 8 Tutorials
 
-Step-by-step tutorials to guide users through Camunda Cloud use cases end-to-end.
+Step-by-step tutorials to guide users through Camunda Platform 8 use cases end-to-end.
 
 Use Cases:
 


### PR DESCRIPTION
@berndruecker is this guide valid for C8 Self-Managed as well? If so, we can keep it as Platform 8 without issues. Otherwise, we might want to change it to Camunda Platform 8 SaaS