### PR TITLE
chore: specify versions for plugins

### DIFF
--- a/orchestrate-microservices/worker-java/pom.xml
+++ b/orchestrate-microservices/worker-java/pom.xml
@@ -21,7 +21,8 @@
 		<plugins>	
 			<plugin>
                 <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>              
+                <artifactId>exec-maven-plugin</artifactId>
+				<version>3.1.0</version>
                 <configuration>                         
     				  <mainClass>io.camunda.getstarted.tutorial.Worker</mainClass>
                 </configuration>
@@ -29,6 +30,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>


### PR DESCRIPTION
Build is currently playing due to no versions are specified.

![image](https://github.com/camunda/camunda-platform-tutorials/assets/133918079/454c7f15-1c16-466b-b496-e1ed869609dc)


Besides, including versions is best practice according to [maven plugin documentation
](https://maven.apache.org/guides/mini/guide-configuring-plugins.html)

> All plugins should have minimal required [information](https://maven.apache.org/ref/current/maven-model/maven.html#class_plugin): groupId, artifactId and version.