### PR TITLE
Rename camunda/zeebe repo

### DIFF
--- a/solutions/order-fulfillment/fetch-goods-worker-go/fetch-goods-worker.go
+++ b/solutions/order-fulfillment/fetch-goods-worker-go/fetch-goods-worker.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/worker"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
+	"github.com/camunda/camunda/clients/go/v8/pkg/entities"
+	"github.com/camunda/camunda/clients/go/v8/pkg/worker"
+	"github.com/camunda/camunda/clients/go/v8/pkg/zbc"
 )
 
 const ZeebeAddr = "0.0.0.0:26500"

--- a/solutions/order-fulfillment/fetch-goods-worker-go/go.mod
+++ b/solutions/order-fulfillment/fetch-goods-worker-go/go.mod
@@ -2,7 +2,7 @@ module go-hello-world
 
 go 1.19
 
-require github.com/camunda/zeebe/clients/go/v8 v8.1.4
+require github.com/camunda/camunda/clients/go/v8 v8.1.4
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect

--- a/solutions/order-fulfillment/fetch-goods-worker-go/go.sum
+++ b/solutions/order-fulfillment/fetch-goods-worker-go/go.sum
@@ -36,8 +36,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
-github.com/camunda/zeebe/clients/go/v8 v8.1.4 h1:cXObvUU+hYKp6zmCgHGwyYJXXXbx+cQprFtEgzQSxgg=
-github.com/camunda/zeebe/clients/go/v8 v8.1.4/go.mod h1:HZ7hlFKAfCkdLeLds0nqEO48FDRl8LCBaAtDu9GxaAI=
+github.com/camunda/camunda/clients/go/v8 v8.1.4 h1:cXObvUU+hYKp6zmCgHGwyYJXXXbx+cQprFtEgzQSxgg=
+github.com/camunda/camunda/clients/go/v8 v8.1.4/go.mod h1:HZ7hlFKAfCkdLeLds0nqEO48FDRl8LCBaAtDu9GxaAI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=


### PR DESCRIPTION
The repository camunda/zeebe will be rename to camunda/camunda, this commit adjusts all references to this repository.

related to https://github.com/camunda/zeebe/issues/18206

