### PR TITLE
Bump Spring SDK, add logger and bump Java version

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/camunda-platform-tutorials.iml
+++ b/.idea/camunda-platform-tutorials.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="spring-zeebe-example" />
+        <module name="part1-spring-boot-worker" />
+      </profile>
+    </annotationProcessing>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_STRING" value="-parameters" />
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="part1-spring-boot-worker" options="-parameters" />
+      <module name="spring-zeebe-example" options="" />
+    </option>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/solutions/order-fulfillment/retrieve-payment-worker-java/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/solutions/order-fulfillment/retrieve-payment-worker-java/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="identity" />
+      <option name="name" value="Camunda Identity" />
+      <option name="url" value="https://artifacts.camunda.com/artifactory/camunda-identity/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="zeebe-snapshots" />
+      <option name="name" value="Zeebe Snapshot Repository" />
+      <option name="url" value="https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/solutions/order-fulfillment/retrieve-payment-worker-java/pom.xml" />
+        <option value="$PROJECT_DIR$/quick-start/microservice orchestration/worker-java/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" default="true" project-jdk-name="graalvm-jdk-21 (2)" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/camunda-platform-tutorials.iml" filepath="$PROJECT_DIR$/.idea/camunda-platform-tutorials.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/quick-start/microservice orchestration/worker-java/README.md
+++ b/quick-start/microservice orchestration/worker-java/README.md
@@ -4,7 +4,7 @@ This project contains a worker that can connect a BPMN service task to whatever 
 
 Requirements:
 
-* Java >= 8
+* Java >= 21
 * Maven
 
 How to run:

--- a/quick-start/microservice orchestration/worker-java/pom.xml
+++ b/quick-start/microservice orchestration/worker-java/pom.xml
@@ -13,7 +13,12 @@
 		<dependency>
 			<groupId>io.camunda</groupId>
 			<artifactId>spring-boot-starter-camunda-sdk</artifactId>
-			<version>8.5.0</version>
+			<version>8.5.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>2.20.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
- The latest version of Spring Zeebe SDK is 8.5.3. To upgrade to that we need to bump the version of Java to 21.

- Added a logging library to improve visibility - apache log4j

- Updated documentation about requirements