### PR TITLE
Fix task listener correction

### DIFF
--- a/quick-start/task-listeners/worker-java/src/main/java/io/camunda/getstarted/tutorial/Listener.java
+++ b/quick-start/task-listeners/worker-java/src/main/java/io/camunda/getstarted/tutorial/Listener.java
@@ -37,7 +37,7 @@ public class Listener {
       client
           .newDeployResourceCommand()
           .addResourceFromClasspath("Quick_Start_Task_Listeners.bpmn")
-          .send();
+          .execute();
       System.out.println("Process deployed successfully.");
     }
     if (SHOULD_CREATE_PROCESS_INSTANCE_ON_STARTUP) {
@@ -46,7 +46,7 @@ public class Listener {
           .bpmnProcessId("task-listener-tutorial")
           .latestVersion()
           .variable("assignee", "john")
-          .send();
+          .execute();
       System.out.println("Process instance created successfully.");
     }
   }
@@ -60,7 +60,7 @@ public class Listener {
           .retries(0)
           .errorMessage(
               "No assignee or manager variable provided. Please set either 'assignee' or 'manager' variable.")
-          .send();
+          .execute();
       System.out.println(
           "Job failed: No assignee or manager variable provided. Incident will be raised.");
       return;
@@ -70,7 +70,7 @@ public class Listener {
     client
         .newCompleteCommand(job)
         .withResult(r -> r.forUserTask().correctAssignee(assignee))
-        .send();
+        .execute();
     System.out.println("Job completed successfully. Task assigned to: " + assignee);
   }
 }

--- a/quick-start/task-listeners/worker-java/src/main/java/io/camunda/getstarted/tutorial/Listener.java
+++ b/quick-start/task-listeners/worker-java/src/main/java/io/camunda/getstarted/tutorial/Listener.java
@@ -1,6 +1,7 @@
 package io.camunda.getstarted.tutorial;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.CompleteJobResult;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.annotation.JobWorker;
 import java.util.Map;
@@ -68,7 +69,7 @@ public class Listener {
     final String assignee = (String) variables.getOrDefault("assignee", variables.get("manager"));
     client
         .newCompleteCommand(job)
-        .variables(Map.of("correctAssignee", assignee))
+        .withResult(r -> r.forUserTask().correctAssignee(assignee))
         .send();
     System.out.println("Job completed successfully. Task assigned to: " + assignee);
   }


### PR DESCRIPTION
In https://github.com/camunda/camunda-8-tutorials/commit/a1bbcf9699e1ea1197a37a8f55020ffea6f8d4b9#diff-8c867ad4dd2efccf8b29fc43083249386e043adca087076a0dcabc2adc535e0cL72-R72, the tutorial was broken by the following change:

```
@@ -69,8 +68,8 @@ public void assignNewUserTasks(final ActivatedJob job) {
    final String assignee = (String) variables.getOrDefault("assignee", variables.get("manager"));
    client
        .newCompleteCommand(job)
-        .withResult(new CompleteJobResult().correctAssignee(assignee))
-        .execute();
+        .variables(Map.of("correctAssignee", assignee))
+        .send();
    System.out.println("Job completed successfully. Task assigned to: " + assignee);
  }
}
```

You cannot (yet) complete listener jobs with variables. Additionally, that wouldn't correct the assignee, which is what the tutorial tries to teach. To correct the assignee, the job must be completed with a result that corrects the assignee.

See: https://camunda.slack.com/archives/C0ALRKGFP6X/p1773746982616789