### PR TITLE
fix(bpmn): fix AI Email Support Agent layout and lint issues

### DIFF
--- a/solutions/bank-ai-loan-approval/AI Email Support Agent.bpmn
+++ b/solutions/bank-ai-loan-approval/AI Email Support Agent.bpmn
@@ -184,7 +184,7 @@
         </bpmn:extensionElements>
       </bpmn:serviceTask>
       <bpmn:intermediateThrowEvent id="Event_0wh5ha7" name="ignore">
-        <bpmn:incoming>Flow_0d4itte</bpmn:incoming>
+        <bpmn:incoming>Flow_137dks7</bpmn:incoming>
       </bpmn:intermediateThrowEvent>
       <bpmn:exclusiveGateway id="Gateway_1whb5u5" name="Save answer to knowledge base?">
         <bpmn:incoming>Flow_0acq6om</bpmn:incoming>
@@ -217,7 +217,7 @@
         <bpmn:incoming>Flow_11xrx39</bpmn:incoming>
       </bpmn:intermediateThrowEvent>
       <bpmn:boundaryEvent id="Event_1wezv96" name="knowledge base empty" attachedToRef="query_knowledge_base">
-        <bpmn:outgoing>Flow_0d4itte</bpmn:outgoing>
+        <bpmn:outgoing>Flow_137dks7</bpmn:outgoing>
         <bpmn:errorEventDefinition id="ErrorEventDefinition_07papr1" errorRef="Error_1xmh0a2" />
       </bpmn:boundaryEvent>
       <bpmn:sequenceFlow id="Flow_0yjq5t1" sourceRef="Reply_with_email_to_customer" targetRef="Event_WaitForResponse" />
@@ -227,7 +227,6 @@
         <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=knowledgeBaseDecision = "yes"</bpmn:conditionExpression>
       </bpmn:sequenceFlow>
       <bpmn:sequenceFlow id="Flow_0j63wm9" sourceRef="Activity_062h34x" targetRef="Gateway_join_specialist" />
-      <bpmn:sequenceFlow id="Flow_0d4itte" sourceRef="Event_1wezv96" targetRef="Event_0wh5ha7" />
       <bpmn:sequenceFlow id="Flow_0acq6om" name="agent" sourceRef="Gateway_1g2difp" targetRef="Gateway_1whb5u5">
         <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(taking_full_control)</bpmn:conditionExpression>
       </bpmn:sequenceFlow>
@@ -238,6 +237,7 @@
       <bpmn:sequenceFlow id="Flow_0q6oul9" name="specialist" sourceRef="Gateway_1g2difp" targetRef="Event_0xzg3s4">
         <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=taking_full_control</bpmn:conditionExpression>
       </bpmn:sequenceFlow>
+      <bpmn:sequenceFlow id="Flow_137dks7" sourceRef="Event_1wezv96" targetRef="Event_0wh5ha7" />
     </bpmn:adHocSubProcess>
     <bpmn:serviceTask id="Activity_0tn95r9" name="Save&#10;customer interaction in long term memory" zeebe:modelerTemplate="io.camunda.connectors.EmbeddingsVectorDB.v1" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMiIgdmlld0JveD0iMCAwIDUxMiA1MTIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSI1MTIiIGhlaWdodD0iNTEyIiBmaWxsPSJ3aGl0ZSIgZmlsbC1vcGFjaXR5PSIwLjAxIiBzdHlsZT0ibWl4LWJsZW5kLW1vZGU6bXVsdGlwbHkiLz4KPHBhdGggZD0iTTI1NS45OTkgMTM2LjcwMkMxOTMuMzE4IDEzNi43MDIgMTI1Ljg1NSAxNTEuNDg1IDEyNS44NTUgMTgzLjkzM1YzOTYuNDc1QzEyNS44NTUgNDI4LjkyMyAxOTMuMzE4IDQ0My43MDcgMjU1Ljk5OSA0NDMuNzA3QzMxOC42NzkgNDQzLjcwNyAzODYuMTQyIDQyOC45MjMgMzg2LjE0MiAzOTYuNDc1VjE4My45MzNDMzg2LjE0MiAxNTEuNDg1IDMxOC42NzkgMTM2LjcwMiAyNTUuOTk5IDEzNi43MDJaTTI1NS45OTkgMTYwLjMxOEMzMjQuNTkxIDE2MC4zMTggMzYwLjA1MyAxNzcuMjUxIDM2Mi40NDIgMTgzLjkzM0MzNjAuMDUzIDE5MC42MTUgMzI0LjU5MSAyMDcuNTQ5IDI1NS45OTkgMjA3LjU0OUMxODYuODg5IDIwNy41NDkgMTUxLjQxOCAxOTAuMzYyIDE0OS41MTggMTg0LjE0MVYxODQuMDgzQzE1MS40MTggMTc3LjUwNSAxODYuODg5IDE2MC4zMTggMjU1Ljk5OSAxNjAuMzE4Wk0xNDkuNTE4IDIxMi41OTlDMTc0LjY5NCAyMjUuMjAzIDIxNi4yNzcgMjMxLjE2NSAyNTUuOTk5IDIzMS4xNjVDMjk1LjcyMSAyMzEuMTY1IDMzNy4zMDQgMjI1LjIwMyAzNjIuNDggMjEyLjU5OVYyNTQuNjMxQzM2MC41OCAyNjEuMjA5IDMyNS4xMDggMjc4LjM5NiAyNTUuOTk5IDI3OC4zOTZDMTg2Ljc4NSAyNzguMzk2IDE1MS4zMDMgMjYxLjE1NyAxNDkuNTE4IDI1NC43ODFWMjEyLjU5OVpNMTQ5LjUxOCAyODMuNDQ3QzE3NC42OTQgMjk2LjA1IDIxNi4yNzcgMzAyLjAxMiAyNTUuOTk5IDMwMi4wMTJDMjk1LjcyMSAzMDIuMDEyIDMzNy4zMDQgMjk2LjA1IDM2Mi40OCAyODMuNDQ3VjMyNS40NzhDMzYwLjU4IDMzMi4wNTYgMzI1LjEwOCAzNDkuMjQ0IDI1NS45OTkgMzQ5LjI0NEMxODYuNzg1IDM0OS4yNDQgMTUxLjMwMyAzMzIuMDA0IDE0OS41MTggMzI1LjYyOFYyODMuNDQ3Wk0yNTUuOTk5IDQyMC4wOTFDMTg2Ljc4NSA0MjAuMDkxIDE1MS4zMDMgNDAyLjg1MSAxNDkuNTE4IDM5Ni40NzVWMzU0LjI5NEMxNzQuNjk0IDM2Ni44OTggMjE2LjI3NyAzNzIuODU5IDI1NS45OTkgMzcyLjg1OUMyOTUuNzIxIDM3Mi44NTkgMzM3LjMwNCAzNjYuODk4IDM2Mi40OCAzNTQuMjk0VjM5Ni4zMjVDMzYwLjU4IDQwMi45MDMgMzI1LjEwOCA0MjAuMDkxIDI1NS45OTkgNDIwLjA5MVoiIGZpbGw9IiNGQzVEMEQiIHN0cm9rZT0iI0ZDNUQwRCIgc3Ryb2tlLXdpZHRoPSI2LjY3NDAyIi8+CjxwYXRoIGQ9Ik0zODcuODYgMzk5Ljg4M0wzNzQuNTMxIDQxMy4yMTFMNDQ2Ljg4NiA0ODUuNTY2SDM4NC4wNTJWNTA0LjYwN0g0NzkuMjU2VjQwOS40MDNINDYwLjIxNVY0NzIuMjM4TDM4Ny44NiAzOTkuODgzWiIgZmlsbD0iI0ZDNUQwRCIgc3Ryb2tlPSIjRkM1RDBEIiBzdHJva2Utd2lkdGg9IjguMzQyNTIiLz4KPHBhdGggZD0iTTEyNC4xMzggMzk5Ljg4M0wxMzcuNDY3IDQxMy4yMTFMNjUuMTExNiA0ODUuNTY2SDEyNy45NDZWNTA0LjYwN0gzMi43NDIyVjQwOS40MDNINTEuNzgzVjQ3Mi4yMzhMMTI0LjEzOCAzOTkuODgzWiIgZmlsbD0iI0ZDNUQwRCIgc3Ryb2tlPSIjRkM1RDBEIiBzdHJva2Utd2lkdGg9IjguMzQyNTIiLz4KPHBhdGggZD0iTTI0Ni41NzUgMTQ2LjA3MUgyNjUuNDI1VjQzLjc0NTNMMzA5Ljg1NiA4OC4xNzYxTDMyMy4zMTkgNzQuNzEyMkwyNTYgNy4zOTI4MkwxODguNjgxIDc0LjcxMjJMMjAyLjE0NCA4OC4xNzYxTDI0Ni41NzUgNDMuNzQ1M1YxNDYuMDcxWiIgZmlsbD0iI0ZDNUQwRCIgc3Ryb2tlPSIjRkM1RDBEIiBzdHJva2Utd2lkdGg9IjguMzQyNTIiLz4KPC9zdmc+Cg==">
       <bpmn:documentation>The agent learns from past interactions and specific customer situations</bpmn:documentation>
@@ -525,14 +525,72 @@
   <bpmn:message id="Message_0whm78z" name="3c562193-4e24-4d28-8407-3f6079e80f0e" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailMessageStart.v1" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0j5qzil">
-      <bpmndi:BPMNShape id="Event_ProcessEnd_di" bpmnElement="Event_ProcessEnd">
-        <dc:Bounds x="2107" y="272" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_1y1vn4t_di" bpmnElement="Activity_0kce977" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="428" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0kp1fqr_di" bpmnElement="Gateway_0kp1fqr" isMarkerVisible="true">
+        <dc:Bounds x="588" y="265" width="50" height="50" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0j1qtdl_di" bpmnElement="Event_WaitForEmail">
+        <dc:Bounds x="322" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2082" y="316" width="87" height="27" />
+          <dc:Bounds x="301" y="316" width="78" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_ProcessEnd_di" bpmnElement="Event_ProcessEnd">
+        <dc:Bounds x="2177" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2152" y="316" width="87" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1omte3n" bpmnElement="Activity_0tn95r9" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="1587" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1lon2qv_di" bpmnElement="Activity_132636m" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="2017" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ua9lj6_di" bpmnElement="Gateway_0ua9lj6" isMarkerVisible="true">
+        <dc:Bounds x="1907" y="265" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1895" y="227.5" width="73" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1va155p_di" bpmnElement="Event_1jfz6dk" bioc:stroke="#5b176d" bioc:fill="#e1bee7" color:background-color="#e1bee7" color:border-color="#5b176d">
+        <dc:Bounds x="2177" y="400" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2159" y="443" width="72" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_human_control_end_di" bpmnElement="Event_human_control_end">
+        <dc:Bounds x="2270" y="400" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2252" y="443" width="72" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_12gbl24" bpmnElement="Activity_0hp732o" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="1747" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11xj1kv" bpmnElement="Activity_0d9av47" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="2210" y="108" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mw9iyy_di" bpmnElement="Event_0mw9iyy">
+        <dc:Bounds x="2362" y="130" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2350" y="173" width="61" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1squlpg" bpmnElement="Activity_1647ldd" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="2017" y="108" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0icwfki_di" bpmnElement="Activity_04glkkx" isExpanded="true">
-        <dc:Bounds x="698" y="85" width="759" height="410" />
+        <dc:Bounds x="698" y="85" width="829" height="410" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0pn4ems_di" bpmnElement="Reply_with_email_to_customer" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
@@ -556,26 +614,10 @@
         <dc:Bounds x="1243" y="120" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0wh5ha7_di" bpmnElement="Event_0wh5ha7">
-        <dc:Bounds x="1395" y="182" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1399" y="225" width="31" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1whb5u5_di" bpmnElement="Gateway_1whb5u5" isMarkerVisible="true">
         <dc:Bounds x="1118" y="290" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1100" y="260" width="86" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_join_specialist_di" bpmnElement="Gateway_join_specialist" isMarkerVisible="true">
-        <dc:Bounds x="1345" y="290" width="50" height="50" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1wd6fel_di" bpmnElement="Event_1wd6fel">
-        <dc:Bounds x="1405" y="297" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1399" y="260" width="48" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0x6ayre" bpmnElement="Gateway_1g2difp" isMarkerVisible="true">
@@ -594,6 +636,22 @@
         <dc:Bounds x="1105" y="127" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1099" y="170" width="50" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_join_specialist_di" bpmnElement="Gateway_join_specialist" isMarkerVisible="true">
+        <dc:Bounds x="1365" y="290" width="50" height="50" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0wh5ha7_di" bpmnElement="Event_0wh5ha7">
+        <dc:Bounds x="1445" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1449" y="225" width="31" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wd6fel_di" bpmnElement="Event_1wd6fel">
+        <dc:Bounds x="1455" y="297" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1449" y="260" width="48" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0obdo5z" bpmnElement="Event_1wezv96">
@@ -623,11 +681,7 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0j63wm9_di" bpmnElement="Flow_0j63wm9">
         <di:waypoint x="1343" y="315" />
-        <di:waypoint x="1345" y="315" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0d4itte_di" bpmnElement="Flow_0d4itte">
-        <di:waypoint x="1351" y="200" />
-        <di:waypoint x="1395" y="200" />
+        <di:waypoint x="1365" y="315" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0acq6om_di" bpmnElement="Flow_0acq6om">
         <di:waypoint x="1038" y="315" />
@@ -639,15 +693,15 @@
       <bpmndi:BPMNEdge id="Flow_0lexqwn_di" bpmnElement="Flow_0lexqwn">
         <di:waypoint x="1143" y="340" />
         <di:waypoint x="1143" y="395" />
-        <di:waypoint x="1370" y="395" />
-        <di:waypoint x="1370" y="340" />
+        <di:waypoint x="1390" y="395" />
+        <di:waypoint x="1390" y="340" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1166" y="358" width="13" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_specialist_join_di" bpmnElement="Flow_specialist_join">
-        <di:waypoint x="1395" y="315" />
-        <di:waypoint x="1405" y="315" />
+        <di:waypoint x="1415" y="315" />
+        <di:waypoint x="1455" y="315" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0q6oul9_di" bpmnElement="Flow_0q6oul9">
         <di:waypoint x="1013" y="340" />
@@ -656,14 +710,10 @@
           <dc:Bounds x="1020" y="367" width="46" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="BPMNShape_1omte3n" bpmnElement="Activity_0tn95r9" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="1517" y="250" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1y1vn4t_di" bpmnElement="Activity_0kce977" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="428" y="250" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_137dks7_di" bpmnElement="Flow_137dks7">
+        <di:waypoint x="1351" y="200" />
+        <di:waypoint x="1445" y="200" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0rqvkub_di" bpmnElement="Activity_0sw5ued" isExpanded="true" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
         <dc:Bounds x="854" y="540" width="448" height="180" />
         <bpmndi:BPMNLabel />
@@ -692,85 +742,47 @@
         <di:waypoint x="1123.5" y="630" />
         <di:waypoint x="1205.5" y="630" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1lon2qv_di" bpmnElement="Activity_132636m" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="1947" y="250" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0ua9lj6_di" bpmnElement="Gateway_0ua9lj6" isMarkerVisible="true">
-        <dc:Bounds x="1837" y="265" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1826" y="315" width="73" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1va155p_di" bpmnElement="Event_1jfz6dk" bioc:stroke="#5b176d" bioc:fill="#e1bee7" color:background-color="#e1bee7" color:border-color="#5b176d">
-        <dc:Bounds x="2107" y="400" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2089" y="443" width="72" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_human_control_end_di" bpmnElement="Event_human_control_end">
-        <dc:Bounds x="2200" y="400" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2182" y="443" width="72" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_12gbl24" bpmnElement="Activity_0hp732o" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
-        <dc:Bounds x="1677" y="250" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_11xj1kv" bpmnElement="Activity_0d9av47" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
-        <dc:Bounds x="2140" y="108" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0kp1fqr_di" bpmnElement="Gateway_0kp1fqr" isMarkerVisible="true">
-        <dc:Bounds x="588" y="265" width="50" height="50" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0mw9iyy_di" bpmnElement="Event_0mw9iyy">
-        <dc:Bounds x="2292" y="130" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2280" y="173" width="61" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1squlpg" bpmnElement="Activity_1647ldd" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="1947" y="108" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0j1qtdl_di" bpmnElement="Event_WaitForEmail">
-        <dc:Bounds x="322" y="272" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="301" y="316" width="78" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1h2tjie_di" bpmnElement="Association_1h2tjie">
+        <di:waypoint x="469" y="250" />
+        <di:waypoint x="460" y="211" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_loan_approval_intro_di" bpmnElement="Association_loan_approval_intro">
         <di:waypoint x="329" y="276" />
         <di:waypoint x="293" y="232" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="TextAnnotation_00q3d45_di" bpmnElement="TextAnnotation_00q3d45">
-        <dc:Bounds x="407" y="170" width="100" height="41" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_0fpqtvh_di" bpmnElement="TextAnnotation_0fpqtvh">
-        <dc:Bounds x="1620" y="170" width="100" height="41" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0p70jxz_di" bpmnElement="Association_0p70jxz">
+        <di:waypoint x="1676" y="250" />
+        <di:waypoint x="1714" y="211" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0fquesm_di" bpmnElement="Event_0fquesm">
         <dc:Bounds x="490" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="504" y="380" width="68" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_human_control_end_di" bpmnElement="Flow_human_control_end">
-        <di:waypoint x="2073" y="418" />
-        <di:waypoint x="2200" y="418" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_00q3d45_di" bpmnElement="TextAnnotation_00q3d45">
+        <dc:Bounds x="407" y="170" width="100" height="41" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_loan_approval_intro_di" bpmnElement="TextAnnotation_loan_approval_intro">
+        <dc:Bounds x="160" y="108" width="230" height="124" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0v6pwqf_di" bpmnElement="Flow_0v6pwqf">
-        <di:waypoint x="2047" y="290" />
-        <di:waypoint x="2107" y="290" />
+        <di:waypoint x="2117" y="290" />
+        <di:waypoint x="2177" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16e6f6v_di" bpmnElement="Flow_16e6f6v">
+        <di:waypoint x="638" y="290" />
+        <di:waypoint x="698" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tw35xw_di" bpmnElement="Flow_1tw35xw">
+        <di:waypoint x="1527" y="290" />
+        <di:waypoint x="1587" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0dqug0r_di" bpmnElement="Flow_0dqug0r">
-        <di:waypoint x="1617" y="290" />
-        <di:waypoint x="1677" y="290" />
+        <di:waypoint x="1687" y="290" />
+        <di:waypoint x="1747" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0fghmqt_di" bpmnElement="Flow_0fghmqt">
         <di:waypoint x="358" y="290" />
@@ -781,35 +793,43 @@
         <di:waypoint x="588" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0nq27w0_di" bpmnElement="Flow_0nq27w0">
-        <di:waypoint x="1887" y="290" />
-        <di:waypoint x="1947" y="290" />
+        <di:waypoint x="1957" y="290" />
+        <di:waypoint x="2017" y="290" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1877" y="272" width="65" height="14" />
+          <dc:Bounds x="1947" y="272" width="65" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ocsi68_di" bpmnElement="Flow_1ocsi68">
-        <di:waypoint x="1777" y="290" />
-        <di:waypoint x="1837" y="290" />
+        <di:waypoint x="1847" y="290" />
+        <di:waypoint x="1907" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0a79ens_di" bpmnElement="Flow_0a79ens">
-        <di:waypoint x="1862" y="315" />
-        <di:waypoint x="1862" y="418" />
-        <di:waypoint x="2107" y="418" />
+        <di:waypoint x="1932" y="315" />
+        <di:waypoint x="1932" y="418" />
+        <di:waypoint x="2177" y="418" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1868" y="386" width="67" height="27" />
+          <dc:Bounds x="1938" y="386" width="67" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0fh19mp_di" bpmnElement="Flow_0fh19mp">
-        <di:waypoint x="1862" y="265" />
-        <di:waypoint x="1862" y="148" />
-        <di:waypoint x="1947" y="148" />
+        <di:waypoint x="1932" y="265" />
+        <di:waypoint x="1932" y="148" />
+        <di:waypoint x="2017" y="148" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1871" y="156" width="55" height="27" />
+          <dc:Bounds x="1941" y="156" width="55" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_human_control_end_di" bpmnElement="Flow_human_control_end">
+        <di:waypoint x="2143" y="418" />
+        <di:waypoint x="2270" y="418" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08s0wt5_di" bpmnElement="Flow_08s0wt5">
-        <di:waypoint x="2047" y="148" />
-        <di:waypoint x="2140" y="148" />
+        <di:waypoint x="2117" y="148" />
+        <di:waypoint x="2210" y="148" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0d6n3x7_di" bpmnElement="Flow_0d6n3x7">
+        <di:waypoint x="2310" y="148" />
+        <di:waypoint x="2362" y="148" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_02rr1ty_di" bpmnElement="Flow_02rr1ty">
         <di:waypoint x="508" y="348" />
@@ -817,28 +837,8 @@
         <di:waypoint x="613" y="368" />
         <di:waypoint x="613" y="315" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0d6n3x7_di" bpmnElement="Flow_0d6n3x7">
-        <di:waypoint x="2240" y="148" />
-        <di:waypoint x="2292" y="148" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_16e6f6v_di" bpmnElement="Flow_16e6f6v">
-        <di:waypoint x="638" y="290" />
-        <di:waypoint x="698" y="290" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1tw35xw_di" bpmnElement="Flow_1tw35xw">
-        <di:waypoint x="1457" y="290" />
-        <di:waypoint x="1517" y="290" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1h2tjie_di" bpmnElement="Association_1h2tjie">
-        <di:waypoint x="469" y="250" />
-        <di:waypoint x="460" y="211" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0p70jxz_di" bpmnElement="Association_0p70jxz">
-        <di:waypoint x="1606" y="250" />
-        <di:waypoint x="1644" y="211" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="TextAnnotation_loan_approval_intro_di" bpmnElement="TextAnnotation_loan_approval_intro">
-        <dc:Bounds x="160" y="108" width="230" height="124" />
+      <bpmndi:BPMNShape id="TextAnnotation_0fpqtvh_di" bpmnElement="TextAnnotation_0fpqtvh">
+        <dc:Bounds x="1690" y="170" width="100" height="41" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/solutions/bank-ai-loan-approval/AI Email Support Agent.bpmn
+++ b/solutions/bank-ai-loan-approval/AI Email Support Agent.bpmn
@@ -526,321 +526,321 @@
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0j5qzil">
       <bpmndi:BPMNShape id="Event_ProcessEnd_di" bpmnElement="Event_ProcessEnd">
-        <dc:Bounds x="2027" y="272" width="36" height="36" />
+        <dc:Bounds x="2107" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2002" y="316" width="87" height="27" />
+          <dc:Bounds x="2082" y="316" width="87" height="27" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0mw9iyy_di" bpmnElement="Event_0mw9iyy">
-        <dc:Bounds x="2212" y="130" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2200" y="173" width="61" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_11xj1kv" bpmnElement="Activity_0d9av47" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
-        <dc:Bounds x="2060" y="108" width="100" height="80" />
-        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0icwfki_di" bpmnElement="Activity_04glkkx" isExpanded="true">
-        <dc:Bounds x="618" y="85" width="759" height="410" />
+        <dc:Bounds x="698" y="85" width="759" height="410" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0pn4ems_di" bpmnElement="Reply_with_email_to_customer" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
-        <dc:Bounds x="663" y="105" width="100" height="80" />
+        <dc:Bounds x="743" y="105" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1r7dbg4_di" bpmnElement="Event_WaitForResponse">
-        <dc:Bounds x="925" y="127" width="36" height="36" />
+        <dc:Bounds x="1005" y="127" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="893" y="171" width="90" height="27" />
+          <dc:Bounds x="973" y="171" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1338851_di" bpmnElement="Ask_a_specialist" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="663" y="275" width="100" height="80" />
+        <dc:Bounds x="743" y="275" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_045jpsd_di" bpmnElement="Activity_062h34x" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="1163" y="275" width="100" height="80" />
+        <dc:Bounds x="1243" y="275" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1c9umdq" bpmnElement="query_knowledge_base" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="1163" y="120" width="100" height="80" />
+        <dc:Bounds x="1243" y="120" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0wh5ha7_di" bpmnElement="Event_0wh5ha7">
-        <dc:Bounds x="1315" y="182" width="36" height="36" />
+        <dc:Bounds x="1395" y="182" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1319" y="225" width="31" height="14" />
+          <dc:Bounds x="1399" y="225" width="31" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1whb5u5_di" bpmnElement="Gateway_1whb5u5" isMarkerVisible="true">
-        <dc:Bounds x="1038" y="290" width="50" height="50" />
+        <dc:Bounds x="1118" y="290" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1020" y="260" width="86" height="27" />
+          <dc:Bounds x="1100" y="260" width="86" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_join_specialist_di" bpmnElement="Gateway_join_specialist" isMarkerVisible="true">
-        <dc:Bounds x="1265" y="290" width="50" height="50" />
+        <dc:Bounds x="1345" y="290" width="50" height="50" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wd6fel_di" bpmnElement="Event_1wd6fel">
-        <dc:Bounds x="1325" y="297" width="36" height="36" />
+        <dc:Bounds x="1405" y="297" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1319" y="260" width="48" height="27" />
+          <dc:Bounds x="1399" y="260" width="48" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0x6ayre" bpmnElement="Gateway_1g2difp" isMarkerVisible="true">
-        <dc:Bounds x="908" y="290" width="50" height="50" />
+        <dc:Bounds x="988" y="290" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="906" y="253" width="56" height="27" />
+          <dc:Bounds x="986" y="253" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0fqmlp5_di" bpmnElement="Event_0xzg3s4" bioc:stroke="#5b176d" bioc:fill="#e1bee7" color:background-color="#e1bee7" color:border-color="#5b176d">
-        <dc:Bounds x="915" y="407" width="36" height="36" />
+        <dc:Bounds x="995" y="407" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="897" y="453" width="72" height="27" />
+          <dc:Bounds x="977" y="453" width="72" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jmzwhr_di" bpmnElement="Event_0jmzwhr">
-        <dc:Bounds x="1025" y="127" width="36" height="36" />
+        <dc:Bounds x="1105" y="127" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1019" y="170" width="50" height="27" />
+          <dc:Bounds x="1099" y="170" width="50" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0obdo5z" bpmnElement="Event_1wezv96">
-        <dc:Bounds x="1235" y="182" width="36" height="36" />
+        <dc:Bounds x="1315" y="182" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1203" y="218" width="80" height="27" />
+          <dc:Bounds x="1283" y="218" width="80" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0yjq5t1_di" bpmnElement="Flow_0yjq5t1">
-        <di:waypoint x="763" y="145" />
-        <di:waypoint x="925" y="145" />
+        <di:waypoint x="843" y="145" />
+        <di:waypoint x="1005" y="145" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_11xrx39_di" bpmnElement="Flow_11xrx39">
-        <di:waypoint x="961" y="145" />
-        <di:waypoint x="1025" y="145" />
+        <di:waypoint x="1041" y="145" />
+        <di:waypoint x="1105" y="145" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1aaxb1w_di" bpmnElement="Flow_1aaxb1w">
-        <di:waypoint x="763" y="315" />
-        <di:waypoint x="908" y="315" />
+        <di:waypoint x="843" y="315" />
+        <di:waypoint x="988" y="315" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1mudddl_di" bpmnElement="Flow_1mudddl">
-        <di:waypoint x="1088" y="315" />
-        <di:waypoint x="1163" y="315" />
+        <di:waypoint x="1168" y="315" />
+        <di:waypoint x="1243" y="315" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1117" y="297" width="18" height="14" />
+          <dc:Bounds x="1197" y="297" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0j63wm9_di" bpmnElement="Flow_0j63wm9">
-        <di:waypoint x="1263" y="315" />
-        <di:waypoint x="1265" y="315" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_specialist_join_di" bpmnElement="Flow_specialist_join">
-        <di:waypoint x="1315" y="315" />
-        <di:waypoint x="1325" y="315" />
+        <di:waypoint x="1343" y="315" />
+        <di:waypoint x="1345" y="315" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0d4itte_di" bpmnElement="Flow_0d4itte">
-        <di:waypoint x="1271" y="200" />
-        <di:waypoint x="1315" y="200" />
+        <di:waypoint x="1351" y="200" />
+        <di:waypoint x="1395" y="200" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0acq6om_di" bpmnElement="Flow_0acq6om">
-        <di:waypoint x="958" y="315" />
         <di:waypoint x="1038" y="315" />
+        <di:waypoint x="1118" y="315" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="972" y="293" width="28" height="14" />
+          <dc:Bounds x="1052" y="293" width="28" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0lexqwn_di" bpmnElement="Flow_0lexqwn">
-        <di:waypoint x="1063" y="340" />
-        <di:waypoint x="1063" y="395" />
-        <di:waypoint x="1290" y="395" />
-        <di:waypoint x="1290" y="340" />
+        <di:waypoint x="1143" y="340" />
+        <di:waypoint x="1143" y="395" />
+        <di:waypoint x="1370" y="395" />
+        <di:waypoint x="1370" y="340" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1086" y="358" width="13" height="14" />
+          <dc:Bounds x="1166" y="358" width="13" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_specialist_join_di" bpmnElement="Flow_specialist_join">
+        <di:waypoint x="1395" y="315" />
+        <di:waypoint x="1405" y="315" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0q6oul9_di" bpmnElement="Flow_0q6oul9">
-        <di:waypoint x="933" y="340" />
-        <di:waypoint x="933" y="407" />
+        <di:waypoint x="1013" y="340" />
+        <di:waypoint x="1013" y="407" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="940" y="367" width="46" height="14" />
+          <dc:Bounds x="1020" y="367" width="46" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_1omte3n" bpmnElement="Activity_0tn95r9" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="1437" y="250" width="100" height="80" />
+        <dc:Bounds x="1517" y="250" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1y1vn4t_di" bpmnElement="Activity_0kce977" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="348" y="250" width="100" height="80" />
+        <dc:Bounds x="428" y="250" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0rqvkub_di" bpmnElement="Activity_0sw5ued" isExpanded="true" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
-        <dc:Bounds x="774" y="540" width="448" height="180" />
+        <dc:Bounds x="854" y="540" width="448" height="180" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_10qjan1_di" bpmnElement="Event_1daac7o" bioc:stroke="#5b176d" bioc:fill="#e1bee7" color:background-color="#e1bee7" color:border-color="#5b176d">
-        <dc:Bounds x="806" y="612" width="36" height="36" />
+        <dc:Bounds x="886" y="612" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="789" y="655" width="72" height="27" />
+          <dc:Bounds x="869" y="655" width="72" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1lf6juj_di" bpmnElement="Activity_0pyk6oo" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="944" y="590" width="100" height="80" />
+        <dc:Bounds x="1024" y="590" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0pcdb7p_di" bpmnElement="Event_0pcdb7p">
-        <dc:Bounds x="1126" y="612" width="36" height="36" />
+        <dc:Bounds x="1206" y="612" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1102" y="655" width="85" height="27" />
+          <dc:Bounds x="1182" y="655" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1sjth1d_di" bpmnElement="Flow_1sjth1d">
-        <di:waypoint x="841.5" y="630" />
-        <di:waypoint x="943.5" y="630" />
+        <di:waypoint x="921.5" y="630" />
+        <di:waypoint x="1023.5" y="630" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0kks6ca_di" bpmnElement="Flow_0kks6ca">
-        <di:waypoint x="1043.5" y="630" />
-        <di:waypoint x="1125.5" y="630" />
+        <di:waypoint x="1123.5" y="630" />
+        <di:waypoint x="1205.5" y="630" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_1lon2qv_di" bpmnElement="Activity_132636m" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="1867" y="250" width="100" height="80" />
+        <dc:Bounds x="1947" y="250" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0ua9lj6_di" bpmnElement="Gateway_0ua9lj6" isMarkerVisible="true">
-        <dc:Bounds x="1757" y="265" width="50" height="50" />
+        <dc:Bounds x="1837" y="265" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1746" y="315" width="73" height="27" />
+          <dc:Bounds x="1826" y="315" width="73" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1va155p_di" bpmnElement="Event_1jfz6dk" bioc:stroke="#5b176d" bioc:fill="#e1bee7" color:background-color="#e1bee7" color:border-color="#5b176d">
-        <dc:Bounds x="2027" y="400" width="36" height="36" />
+        <dc:Bounds x="2107" y="400" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2009" y="443" width="72" height="27" />
+          <dc:Bounds x="2089" y="443" width="72" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_human_control_end_di" bpmnElement="Event_human_control_end">
+        <dc:Bounds x="2200" y="400" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2182" y="443" width="72" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_12gbl24" bpmnElement="Activity_0hp732o" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
-        <dc:Bounds x="1597" y="250" width="100" height="80" />
+        <dc:Bounds x="1677" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11xj1kv" bpmnElement="Activity_0d9av47" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="2140" y="108" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0kp1fqr_di" bpmnElement="Gateway_0kp1fqr" isMarkerVisible="true">
-        <dc:Bounds x="508" y="265" width="50" height="50" />
+        <dc:Bounds x="588" y="265" width="50" height="50" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mw9iyy_di" bpmnElement="Event_0mw9iyy">
+        <dc:Bounds x="2292" y="130" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2280" y="173" width="61" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1squlpg" bpmnElement="Activity_1647ldd" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="1867" y="108" width="100" height="80" />
+        <dc:Bounds x="1947" y="108" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0j1qtdl_di" bpmnElement="Event_WaitForEmail">
-        <dc:Bounds x="242" y="272" width="36" height="36" />
+        <dc:Bounds x="322" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="221" y="316" width="78" height="27" />
+          <dc:Bounds x="301" y="316" width="78" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_loan_approval_intro_di" bpmnElement="Association_loan_approval_intro">
+        <di:waypoint x="329" y="276" />
+        <di:waypoint x="293" y="232" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="TextAnnotation_00q3d45_di" bpmnElement="TextAnnotation_00q3d45">
-        <dc:Bounds x="327" y="170" width="100" height="41" />
+        <dc:Bounds x="407" y="170" width="100" height="41" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_0fpqtvh_di" bpmnElement="TextAnnotation_0fpqtvh">
-        <dc:Bounds x="1540" y="170" width="100" height="41" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_human_control_end_di" bpmnElement="Event_human_control_end">
-        <dc:Bounds x="2120" y="400" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2097" y="443" width="82" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_human_control_end_di" bpmnElement="Flow_human_control_end">
-        <di:waypoint x="1993" y="418" />
-        <di:waypoint x="2120" y="418" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="TextAnnotation_loan_approval_intro_di" bpmnElement="TextAnnotation_loan_approval_intro">
-        <dc:Bounds x="160" y="155" width="230" height="82" />
+        <dc:Bounds x="1620" y="170" width="100" height="41" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0fquesm_di" bpmnElement="Event_0fquesm">
-        <dc:Bounds x="410" y="312" width="36" height="36" />
+        <dc:Bounds x="490" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="424" y="380" width="68" height="40" />
+          <dc:Bounds x="504" y="380" width="68" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_human_control_end_di" bpmnElement="Flow_human_control_end">
+        <di:waypoint x="2073" y="418" />
+        <di:waypoint x="2200" y="418" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0v6pwqf_di" bpmnElement="Flow_0v6pwqf">
-        <di:waypoint x="1967" y="290" />
-        <di:waypoint x="2027" y="290" />
+        <di:waypoint x="2047" y="290" />
+        <di:waypoint x="2107" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0dqug0r_di" bpmnElement="Flow_0dqug0r">
-        <di:waypoint x="1537" y="290" />
-        <di:waypoint x="1597" y="290" />
+        <di:waypoint x="1617" y="290" />
+        <di:waypoint x="1677" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0fghmqt_di" bpmnElement="Flow_0fghmqt">
-        <di:waypoint x="278" y="290" />
-        <di:waypoint x="348" y="290" />
+        <di:waypoint x="358" y="290" />
+        <di:waypoint x="428" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0coeih9_di" bpmnElement="Flow_0coeih9">
-        <di:waypoint x="448" y="290" />
-        <di:waypoint x="508" y="290" />
+        <di:waypoint x="528" y="290" />
+        <di:waypoint x="588" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0nq27w0_di" bpmnElement="Flow_0nq27w0">
-        <di:waypoint x="1807" y="290" />
-        <di:waypoint x="1867" y="290" />
+        <di:waypoint x="1887" y="290" />
+        <di:waypoint x="1947" y="290" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1797" y="272" width="65" height="14" />
+          <dc:Bounds x="1877" y="272" width="65" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ocsi68_di" bpmnElement="Flow_1ocsi68">
-        <di:waypoint x="1697" y="290" />
-        <di:waypoint x="1757" y="290" />
+        <di:waypoint x="1777" y="290" />
+        <di:waypoint x="1837" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0a79ens_di" bpmnElement="Flow_0a79ens">
-        <di:waypoint x="1782" y="315" />
-        <di:waypoint x="1782" y="418" />
-        <di:waypoint x="2027" y="418" />
+        <di:waypoint x="1862" y="315" />
+        <di:waypoint x="1862" y="418" />
+        <di:waypoint x="2107" y="418" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1788" y="386" width="67" height="27" />
+          <dc:Bounds x="1868" y="386" width="67" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0fh19mp_di" bpmnElement="Flow_0fh19mp">
-        <di:waypoint x="1782" y="265" />
-        <di:waypoint x="1782" y="148" />
-        <di:waypoint x="1867" y="148" />
+        <di:waypoint x="1862" y="265" />
+        <di:waypoint x="1862" y="148" />
+        <di:waypoint x="1947" y="148" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1791" y="156" width="55" height="27" />
+          <dc:Bounds x="1871" y="156" width="55" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08s0wt5_di" bpmnElement="Flow_08s0wt5">
-        <di:waypoint x="1967" y="148" />
-        <di:waypoint x="2060" y="148" />
+        <di:waypoint x="2047" y="148" />
+        <di:waypoint x="2140" y="148" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_02rr1ty_di" bpmnElement="Flow_02rr1ty">
-        <di:waypoint x="428" y="348" />
-        <di:waypoint x="428" y="368" />
-        <di:waypoint x="533" y="368" />
-        <di:waypoint x="533" y="315" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_16e6f6v_di" bpmnElement="Flow_16e6f6v">
-        <di:waypoint x="558" y="290" />
-        <di:waypoint x="618" y="290" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1tw35xw_di" bpmnElement="Flow_1tw35xw">
-        <di:waypoint x="1377" y="290" />
-        <di:waypoint x="1437" y="290" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1h2tjie_di" bpmnElement="Association_1h2tjie">
-        <di:waypoint x="389" y="250" />
-        <di:waypoint x="380" y="211" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0p70jxz_di" bpmnElement="Association_0p70jxz">
-        <di:waypoint x="1526" y="250" />
-        <di:waypoint x="1564" y="211" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_loan_approval_intro_di" bpmnElement="Association_loan_approval_intro">
-        <di:waypoint x="260" y="272" />
-        <di:waypoint x="260" y="237" />
+        <di:waypoint x="508" y="348" />
+        <di:waypoint x="508" y="368" />
+        <di:waypoint x="613" y="368" />
+        <di:waypoint x="613" y="315" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0d6n3x7_di" bpmnElement="Flow_0d6n3x7">
-        <di:waypoint x="2160" y="148" />
-        <di:waypoint x="2212" y="148" />
+        <di:waypoint x="2240" y="148" />
+        <di:waypoint x="2292" y="148" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16e6f6v_di" bpmnElement="Flow_16e6f6v">
+        <di:waypoint x="638" y="290" />
+        <di:waypoint x="698" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tw35xw_di" bpmnElement="Flow_1tw35xw">
+        <di:waypoint x="1457" y="290" />
+        <di:waypoint x="1517" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1h2tjie_di" bpmnElement="Association_1h2tjie">
+        <di:waypoint x="469" y="250" />
+        <di:waypoint x="460" y="211" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0p70jxz_di" bpmnElement="Association_0p70jxz">
+        <di:waypoint x="1606" y="250" />
+        <di:waypoint x="1644" y="211" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_loan_approval_intro_di" bpmnElement="TextAnnotation_loan_approval_intro">
+        <dc:Bounds x="160" y="108" width="230" height="124" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/solutions/bank-ai-loan-approval/AI Email Support Agent.bpmn
+++ b/solutions/bank-ai-loan-approval/AI Email Support Agent.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.43.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.45.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
   <bpmn:process id="Process_0j5qzil" name="Agent Blueprint (Long Term Memory)" isExecutable="true">
     <bpmn:endEvent id="Event_ProcessEnd" name="Case resolution applied by human">
       <bpmn:extensionElements>
@@ -191,9 +191,13 @@
         <bpmn:outgoing>Flow_1mudddl</bpmn:outgoing>
         <bpmn:outgoing>Flow_0lexqwn</bpmn:outgoing>
       </bpmn:exclusiveGateway>
-      <bpmn:intermediateThrowEvent id="Event_1wd6fel" name="Specialist answered">
+      <bpmn:exclusiveGateway id="Gateway_join_specialist">
         <bpmn:incoming>Flow_0j63wm9</bpmn:incoming>
         <bpmn:incoming>Flow_0lexqwn</bpmn:incoming>
+        <bpmn:outgoing>Flow_specialist_join</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:intermediateThrowEvent id="Event_1wd6fel" name="Specialist answered">
+        <bpmn:incoming>Flow_specialist_join</bpmn:incoming>
       </bpmn:intermediateThrowEvent>
       <bpmn:exclusiveGateway id="Gateway_1g2difp" name="Who keeps control?">
         <bpmn:incoming>Flow_1aaxb1w</bpmn:incoming>
@@ -202,7 +206,7 @@
       </bpmn:exclusiveGateway>
       <bpmn:intermediateThrowEvent id="Event_0xzg3s4" name="Human control required">
         <bpmn:incoming>Flow_0q6oul9</bpmn:incoming>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_1h6o509" escalationRef="Escalation_1x4421v" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_1h6o509" escalationRef="Escalation_1qaovql" />
       </bpmn:intermediateThrowEvent>
       <bpmn:intermediateThrowEvent id="Event_0jmzwhr" name="Response correlated">
         <bpmn:extensionElements>
@@ -214,7 +218,7 @@
       </bpmn:intermediateThrowEvent>
       <bpmn:boundaryEvent id="Event_1wezv96" name="knowledge base empty" attachedToRef="query_knowledge_base">
         <bpmn:outgoing>Flow_0d4itte</bpmn:outgoing>
-        <bpmn:errorEventDefinition id="ErrorEventDefinition_07papr1" errorRef="Error_04dhtpa" />
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_07papr1" errorRef="Error_1xmh0a2" />
       </bpmn:boundaryEvent>
       <bpmn:sequenceFlow id="Flow_0yjq5t1" sourceRef="Reply_with_email_to_customer" targetRef="Event_WaitForResponse" />
       <bpmn:sequenceFlow id="Flow_11xrx39" sourceRef="Event_WaitForResponse" targetRef="Event_0jmzwhr" />
@@ -222,14 +226,15 @@
       <bpmn:sequenceFlow id="Flow_1mudddl" name="yes" sourceRef="Gateway_1whb5u5" targetRef="Activity_062h34x">
         <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=knowledgeBaseDecision = "yes"</bpmn:conditionExpression>
       </bpmn:sequenceFlow>
-      <bpmn:sequenceFlow id="Flow_0j63wm9" sourceRef="Activity_062h34x" targetRef="Event_1wd6fel" />
+      <bpmn:sequenceFlow id="Flow_0j63wm9" sourceRef="Activity_062h34x" targetRef="Gateway_join_specialist" />
       <bpmn:sequenceFlow id="Flow_0d4itte" sourceRef="Event_1wezv96" targetRef="Event_0wh5ha7" />
       <bpmn:sequenceFlow id="Flow_0acq6om" name="agent" sourceRef="Gateway_1g2difp" targetRef="Gateway_1whb5u5">
         <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(taking_full_control)</bpmn:conditionExpression>
       </bpmn:sequenceFlow>
-      <bpmn:sequenceFlow id="Flow_0lexqwn" name="no" sourceRef="Gateway_1whb5u5" targetRef="Event_1wd6fel">
+      <bpmn:sequenceFlow id="Flow_0lexqwn" name="no" sourceRef="Gateway_1whb5u5" targetRef="Gateway_join_specialist">
         <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=knowledgeBaseDecision = "no"</bpmn:conditionExpression>
       </bpmn:sequenceFlow>
+      <bpmn:sequenceFlow id="Flow_specialist_join" sourceRef="Gateway_join_specialist" targetRef="Event_1wd6fel" />
       <bpmn:sequenceFlow id="Flow_0q6oul9" name="specialist" sourceRef="Gateway_1g2difp" targetRef="Event_0xzg3s4">
         <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=taking_full_control</bpmn:conditionExpression>
       </bpmn:sequenceFlow>
@@ -304,7 +309,7 @@
     <bpmn:subProcess id="Activity_0sw5ued" name="Human controlled request" triggeredByEvent="true">
       <bpmn:startEvent id="Event_1daac7o" name="Human control required">
         <bpmn:outgoing>Flow_1sjth1d</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0hx6e2i" escalationRef="Escalation_1fpfwz8" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0hx6e2i" escalationRef="Escalation_1qaovql" />
       </bpmn:startEvent>
       <bpmn:userTask id="Activity_0pyk6oo" name="Handle customer request">
         <bpmn:extensionElements>
@@ -351,8 +356,13 @@
     </bpmn:exclusiveGateway>
     <bpmn:intermediateThrowEvent id="Event_1jfz6dk" name="Human control required">
       <bpmn:incoming>Flow_0a79ens</bpmn:incoming>
+      <bpmn:outgoing>Flow_human_control_end</bpmn:outgoing>
       <bpmn:escalationEventDefinition id="EscalationEventDefinition_06njmsk" escalationRef="Escalation_1qaovql" />
     </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="Event_human_control_end" name="Human control triggered">
+      <bpmn:incoming>Flow_human_control_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_human_control_end" sourceRef="Event_1jfz6dk" targetRef="Event_human_control_end" />
     <bpmn:serviceTask id="Activity_0hp732o" name="Agent as a Judge" zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v1" zeebe:modelerTemplateVersion="4" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="io.camunda.agenticai:aiagent:1" retries="3" />
@@ -414,8 +424,8 @@
           <zeebe:header key="retryBackoff" value="PT0S" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0fh19mp</bpmn:incoming>
-      <bpmn:outgoing>Flow_08s0wt5</bpmn:outgoing>
+      <bpmn:incoming>Flow_08s0wt5</bpmn:incoming>
+      <bpmn:outgoing>Flow_0d6n3x7</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="Gateway_0kp1fqr">
       <bpmn:incoming>Flow_0coeih9</bpmn:incoming>
@@ -442,8 +452,8 @@
         </zeebe:ioMapping>
         <zeebe:formDefinition formId="review-case-resolution-04315tw" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_08s0wt5</bpmn:incoming>
-      <bpmn:outgoing>Flow_0d6n3x7</bpmn:outgoing>
+      <bpmn:incoming>Flow_0fh19mp</bpmn:incoming>
+      <bpmn:outgoing>Flow_08s0wt5</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:boundaryEvent id="Event_0fquesm" name="No past conversations found" attachedToRef="Activity_0kce977">
       <bpmn:outgoing>Flow_02rr1ty</bpmn:outgoing>
@@ -458,12 +468,12 @@
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1ocsi68" sourceRef="Activity_0hp732o" targetRef="Gateway_0ua9lj6" />
     <bpmn:sequenceFlow id="Flow_0a79ens" name="needs human resolution" sourceRef="Gateway_0ua9lj6" targetRef="Event_1jfz6dk" />
-    <bpmn:sequenceFlow id="Flow_0fh19mp" name="solved with confidence" sourceRef="Gateway_0ua9lj6" targetRef="Activity_0d9av47">
+    <bpmn:sequenceFlow id="Flow_0fh19mp" name="solved with confidence" sourceRef="Gateway_0ua9lj6" targetRef="Activity_1647ldd">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=decision = "AGENT_SUCCESS"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_08s0wt5" sourceRef="Activity_0d9av47" targetRef="Activity_1647ldd" />
+    <bpmn:sequenceFlow id="Flow_08s0wt5" sourceRef="Activity_1647ldd" targetRef="Activity_0d9av47" />
     <bpmn:sequenceFlow id="Flow_02rr1ty" sourceRef="Event_0fquesm" targetRef="Gateway_0kp1fqr" />
-    <bpmn:sequenceFlow id="Flow_0d6n3x7" sourceRef="Activity_1647ldd" targetRef="Event_0mw9iyy" />
+    <bpmn:sequenceFlow id="Flow_0d6n3x7" sourceRef="Activity_0d9av47" targetRef="Event_0mw9iyy" />
     <bpmn:sequenceFlow id="Flow_16e6f6v" sourceRef="Gateway_0kp1fqr" targetRef="Activity_04glkkx" />
     <bpmn:sequenceFlow id="Flow_1tw35xw" sourceRef="Activity_04glkkx" targetRef="Activity_0tn95r9" />
     <bpmn:startEvent id="Event_WaitForEmail" name="Customer email received" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailMessageStart.v1" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzkwXzI0MjApIj4KPHBhdGggZD0iTTguMzM4MzUgOS45NTM2NUwxMC4zODk0IDEyLjAxMDRMOC4zMzI2MiAxNC4wNjcyTDkuMTQ2MTYgMTQuODc1TDEyLjAxMDcgMTIuMDEwNEw5LjE0NjE2IDkuMTQ1ODNMOC4zMzgzNSA5Ljk1MzY1WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEyLjM0ODggOS45NTM2NUwxNC4zOTk4IDEyLjAxMDRMMTIuMzQzIDE0LjA2NzJMMTMuMTU2NiAxNC44NzVMMTYuMDIxMiAxMi4wMTA0TDEzLjE1NjYgOS4xNDU4M0wxMi4zNDg4IDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMy45NzIgMTEuNDM3NUgxLjEyNTMzVjIuNzkyMTlMNy42NzM3NiA3LjMyMzk2QzcuNzY5NjcgNy4zOTA0OSA3Ljg4MzYgNy40MjYxNCA4LjAwMDMyIDcuNDI2MTRDOC4xMTcwNSA3LjQyNjE0IDguMjMwOTggNy4zOTA0OSA4LjMyNjg5IDcuMzIzOTZMMTQuODc1MyAyLjc5MjE5VjhIMTYuMDIxMlYyLjI3MDgzQzE2LjAyMTIgMS45NjY5NCAxNS45MDA0IDEuNjc1NDkgMTUuNjg1NiAxLjQ2MDYxQzE1LjQ3MDcgMS4yNDU3MiAxNS4xNzkyIDEuMTI1IDE0Ljg3NTMgMS4xMjVIMS4xMjUzM0MwLjgyMTQzMiAxLjEyNSAwLjUyOTk4NCAxLjI0NTcyIDAuMzE1MDk5IDEuNDYwNjFDMC4xMDAyMTQgMS42NzU0OSAtMC4wMjA1MDc4IDEuOTY2OTQgLTAuMDIwNTA3OCAyLjI3MDgzVjExLjQzNzVDLTAuMDIwNTA3OCAxMS43NDE0IDAuMTAwMjE0IDEyLjAzMjggMC4zMTUwOTkgMTIuMjQ3N0MwLjUyOTk4NCAxMi40NjI2IDAuODIxNDMyIDEyLjU4MzMgMS4xMjUzMyAxMi41ODMzSDMuOTcyVjExLjQzNzVaTTEzLjYxNDkgMi4yNzA4M0w4LjAwMDMyIDYuMTU1MjFMMi4zODU3NCAyLjI3MDgzSDEzLjYxNDlaIiBmaWxsPSIjRkM1RDBEIi8+CjxwYXRoIGQ9Ik00LjI4MjEgOS45NTM2NUw2LjMzMzE0IDEyLjAxMDRMNC4yNzYzNyAxNC4wNjcyTDUuMDg5OTEgMTQuODc1TDcuOTU0NDkgMTIuMDEwNEw1LjA4OTkxIDkuMTQ1ODNMNC4yODIxIDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzkwXzI0MjAiPgo8cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==">
@@ -512,304 +522,324 @@
       <zeebe:subscription correlationKey="=ourReplyEmail.messageId" />
     </bpmn:extensionElements>
   </bpmn:message>
-  <bpmn:escalation id="Escalation_1x4421v" name="human escalation" escalationCode="100_human_escalation" />
-  <bpmn:escalation id="Escalation_1fpfwz8" name="human escalation" escalationCode="100_human_escalation" />
-  <bpmn:error id="Error_04dhtpa" name="index_not_found" errorCode="index_not_found" />
-  <bpmn:message id="Message_0fr5ip9" name="116d29be-ca23-4ab4-acfd-f3a278c341e2">
-    <bpmn:extensionElements />
-  </bpmn:message>
   <bpmn:message id="Message_0whm78z" name="3c562193-4e24-4d28-8407-3f6079e80f0e" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailMessageStart.v1" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0j5qzil">
       <bpmndi:BPMNShape id="Event_ProcessEnd_di" bpmnElement="Event_ProcessEnd">
-        <dc:Bounds x="1957" y="272" width="36" height="36" />
+        <dc:Bounds x="2027" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1932" y="316" width="87" height="27" />
+          <dc:Bounds x="2002" y="316" width="87" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mw9iyy_di" bpmnElement="Event_0mw9iyy">
+        <dc:Bounds x="2212" y="130" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2200" y="173" width="61" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11xj1kv" bpmnElement="Activity_0d9av47" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="2060" y="108" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0icwfki_di" bpmnElement="Activity_04glkkx" isExpanded="true">
-        <dc:Bounds x="548" y="85" width="759" height="410" />
+        <dc:Bounds x="618" y="85" width="759" height="410" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0pn4ems_di" bpmnElement="Reply_with_email_to_customer" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
-        <dc:Bounds x="593" y="105" width="100" height="80" />
+        <dc:Bounds x="663" y="105" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1r7dbg4_di" bpmnElement="Event_WaitForResponse">
-        <dc:Bounds x="855" y="127" width="36" height="36" />
+        <dc:Bounds x="925" y="127" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="823" y="171" width="90" height="27" />
+          <dc:Bounds x="893" y="171" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1338851_di" bpmnElement="Ask_a_specialist" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="593" y="275" width="100" height="80" />
+        <dc:Bounds x="663" y="275" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_045jpsd_di" bpmnElement="Activity_062h34x" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="1093" y="275" width="100" height="80" />
+        <dc:Bounds x="1163" y="275" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1c9umdq" bpmnElement="query_knowledge_base" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="1093" y="120" width="100" height="80" />
+        <dc:Bounds x="1163" y="120" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0wh5ha7_di" bpmnElement="Event_0wh5ha7">
-        <dc:Bounds x="1245" y="182" width="36" height="36" />
+        <dc:Bounds x="1315" y="182" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1249" y="225" width="31" height="14" />
+          <dc:Bounds x="1319" y="225" width="31" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1whb5u5_di" bpmnElement="Gateway_1whb5u5" isMarkerVisible="true">
-        <dc:Bounds x="968" y="290" width="50" height="50" />
+        <dc:Bounds x="1038" y="290" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="952" y="260" width="82" height="27" />
+          <dc:Bounds x="1020" y="260" width="86" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_join_specialist_di" bpmnElement="Gateway_join_specialist" isMarkerVisible="true">
+        <dc:Bounds x="1265" y="290" width="50" height="50" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wd6fel_di" bpmnElement="Event_1wd6fel">
-        <dc:Bounds x="1245" y="297" width="36" height="36" />
+        <dc:Bounds x="1325" y="297" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1239" y="260" width="48" height="27" />
+          <dc:Bounds x="1319" y="260" width="48" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0x6ayre" bpmnElement="Gateway_1g2difp" isMarkerVisible="true">
-        <dc:Bounds x="838" y="290" width="50" height="50" />
+        <dc:Bounds x="908" y="290" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="836" y="253" width="56" height="27" />
+          <dc:Bounds x="906" y="253" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0fqmlp5_di" bpmnElement="Event_0xzg3s4" bioc:stroke="#5b176d" bioc:fill="#e1bee7" color:background-color="#e1bee7" color:border-color="#5b176d">
-        <dc:Bounds x="845" y="407" width="36" height="36" />
+        <dc:Bounds x="915" y="407" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="827" y="453" width="72" height="27" />
+          <dc:Bounds x="897" y="453" width="72" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jmzwhr_di" bpmnElement="Event_0jmzwhr">
-        <dc:Bounds x="955" y="127" width="36" height="36" />
+        <dc:Bounds x="1025" y="127" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="949" y="170" width="50" height="27" />
+          <dc:Bounds x="1019" y="170" width="50" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0obdo5z" bpmnElement="Event_1wezv96">
-        <dc:Bounds x="1165" y="182" width="36" height="36" />
+        <dc:Bounds x="1235" y="182" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1133" y="218" width="80" height="27" />
+          <dc:Bounds x="1203" y="218" width="80" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0yjq5t1_di" bpmnElement="Flow_0yjq5t1">
-        <di:waypoint x="693" y="145" />
-        <di:waypoint x="855" y="145" />
+        <di:waypoint x="763" y="145" />
+        <di:waypoint x="925" y="145" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_11xrx39_di" bpmnElement="Flow_11xrx39">
-        <di:waypoint x="891" y="145" />
-        <di:waypoint x="955" y="145" />
+        <di:waypoint x="961" y="145" />
+        <di:waypoint x="1025" y="145" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1aaxb1w_di" bpmnElement="Flow_1aaxb1w">
-        <di:waypoint x="693" y="315" />
-        <di:waypoint x="838" y="315" />
+        <di:waypoint x="763" y="315" />
+        <di:waypoint x="908" y="315" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1mudddl_di" bpmnElement="Flow_1mudddl">
-        <di:waypoint x="1018" y="315" />
-        <di:waypoint x="1093" y="315" />
+        <di:waypoint x="1088" y="315" />
+        <di:waypoint x="1163" y="315" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1047" y="297" width="18" height="14" />
+          <dc:Bounds x="1117" y="297" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0j63wm9_di" bpmnElement="Flow_0j63wm9">
-        <di:waypoint x="1193" y="315" />
-        <di:waypoint x="1245" y="315" />
+        <di:waypoint x="1263" y="315" />
+        <di:waypoint x="1265" y="315" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_specialist_join_di" bpmnElement="Flow_specialist_join">
+        <di:waypoint x="1315" y="315" />
+        <di:waypoint x="1325" y="315" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0d4itte_di" bpmnElement="Flow_0d4itte">
-        <di:waypoint x="1201" y="200" />
-        <di:waypoint x="1245" y="200" />
+        <di:waypoint x="1271" y="200" />
+        <di:waypoint x="1315" y="200" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0acq6om_di" bpmnElement="Flow_0acq6om">
-        <di:waypoint x="888" y="315" />
-        <di:waypoint x="968" y="315" />
+        <di:waypoint x="958" y="315" />
+        <di:waypoint x="1038" y="315" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="902" y="293" width="28" height="14" />
+          <dc:Bounds x="972" y="293" width="28" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0lexqwn_di" bpmnElement="Flow_0lexqwn">
-        <di:waypoint x="993" y="340" />
-        <di:waypoint x="993" y="395" />
-        <di:waypoint x="1263" y="395" />
-        <di:waypoint x="1263" y="333" />
+        <di:waypoint x="1063" y="340" />
+        <di:waypoint x="1063" y="395" />
+        <di:waypoint x="1290" y="395" />
+        <di:waypoint x="1290" y="340" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1016" y="358" width="13" height="14" />
+          <dc:Bounds x="1086" y="358" width="13" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0q6oul9_di" bpmnElement="Flow_0q6oul9">
-        <di:waypoint x="863" y="340" />
-        <di:waypoint x="863" y="407" />
+        <di:waypoint x="933" y="340" />
+        <di:waypoint x="933" y="407" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="870" y="367" width="46" height="14" />
+          <dc:Bounds x="940" y="367" width="46" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_1omte3n" bpmnElement="Activity_0tn95r9" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="1367" y="250" width="100" height="80" />
+        <dc:Bounds x="1437" y="250" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1y1vn4t_di" bpmnElement="Activity_0kce977" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="278" y="250" width="100" height="80" />
+        <dc:Bounds x="348" y="250" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0rqvkub_di" bpmnElement="Activity_0sw5ued" isExpanded="true" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
-        <dc:Bounds x="703.5" y="540" width="448" height="180" />
+        <dc:Bounds x="774" y="540" width="448" height="180" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_10qjan1_di" bpmnElement="Event_1daac7o" bioc:stroke="#5b176d" bioc:fill="#e1bee7" color:background-color="#e1bee7" color:border-color="#5b176d">
-        <dc:Bounds x="735.5" y="612" width="36" height="36" />
+        <dc:Bounds x="806" y="612" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="718.5" y="655" width="72" height="27" />
+          <dc:Bounds x="789" y="655" width="72" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1lf6juj_di" bpmnElement="Activity_0pyk6oo" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="873.5" y="590" width="100" height="80" />
+        <dc:Bounds x="944" y="590" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0pcdb7p_di" bpmnElement="Event_0pcdb7p">
-        <dc:Bounds x="1055.5" y="612" width="36" height="36" />
+        <dc:Bounds x="1126" y="612" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1031.5" y="655" width="85" height="27" />
+          <dc:Bounds x="1102" y="655" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1sjth1d_di" bpmnElement="Flow_1sjth1d">
-        <di:waypoint x="771.5" y="630" />
-        <di:waypoint x="873.5" y="630" />
+        <di:waypoint x="841.5" y="630" />
+        <di:waypoint x="943.5" y="630" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0kks6ca_di" bpmnElement="Flow_0kks6ca">
-        <di:waypoint x="973.5" y="630" />
-        <di:waypoint x="1055.5" y="630" />
+        <di:waypoint x="1043.5" y="630" />
+        <di:waypoint x="1125.5" y="630" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_1lon2qv_di" bpmnElement="Activity_132636m" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="1797" y="250" width="100" height="80" />
+        <dc:Bounds x="1867" y="250" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0ua9lj6_di" bpmnElement="Gateway_0ua9lj6" isMarkerVisible="true">
-        <dc:Bounds x="1687" y="265" width="50" height="50" />
+        <dc:Bounds x="1757" y="265" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1746" y="315" width="73" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1va155p_di" bpmnElement="Event_1jfz6dk" bioc:stroke="#5b176d" bioc:fill="#e1bee7" color:background-color="#e1bee7" color:border-color="#5b176d">
-        <dc:Bounds x="1957" y="400" width="36" height="36" />
+        <dc:Bounds x="2027" y="400" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1939" y="443" width="72" height="27" />
+          <dc:Bounds x="2009" y="443" width="72" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_12gbl24" bpmnElement="Activity_0hp732o" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
-        <dc:Bounds x="1527" y="250" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_11xj1kv" bpmnElement="Activity_0d9av47" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
-        <dc:Bounds x="1797" y="108" width="100" height="80" />
+        <dc:Bounds x="1597" y="250" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0kp1fqr_di" bpmnElement="Gateway_0kp1fqr" isMarkerVisible="true">
-        <dc:Bounds x="438" y="265" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0mw9iyy_di" bpmnElement="Event_0mw9iyy">
-        <dc:Bounds x="1957" y="130" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1945" y="173" width="61" height="14" />
-        </bpmndi:BPMNLabel>
+        <dc:Bounds x="508" y="265" width="50" height="50" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1squlpg" bpmnElement="Activity_1647ldd" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="2050" y="108" width="100" height="80" />
+        <dc:Bounds x="1867" y="108" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0j1qtdl_di" bpmnElement="Event_WaitForEmail">
-        <dc:Bounds x="172" y="272" width="36" height="36" />
+        <dc:Bounds x="242" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="151" y="316" width="78" height="27" />
+          <dc:Bounds x="221" y="316" width="78" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_00q3d45_di" bpmnElement="TextAnnotation_00q3d45">
-        <dc:Bounds x="257" y="170" width="100" height="41" />
+        <dc:Bounds x="327" y="170" width="100" height="41" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_0fpqtvh_di" bpmnElement="TextAnnotation_0fpqtvh">
-        <dc:Bounds x="1470" y="170" width="100" height="41" />
+        <dc:Bounds x="1540" y="170" width="100" height="41" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_human_control_end_di" bpmnElement="Event_human_control_end">
+        <dc:Bounds x="2120" y="400" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2097" y="443" width="82" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_human_control_end_di" bpmnElement="Flow_human_control_end">
+        <di:waypoint x="1993" y="418" />
+        <di:waypoint x="2120" y="418" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_loan_approval_intro_di" bpmnElement="TextAnnotation_loan_approval_intro">
+        <dc:Bounds x="160" y="155" width="230" height="82" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0fquesm_di" bpmnElement="Event_0fquesm">
-        <dc:Bounds x="340" y="312" width="36" height="36" />
+        <dc:Bounds x="410" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="354" y="380" width="68" height="40" />
+          <dc:Bounds x="424" y="380" width="68" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0v6pwqf_di" bpmnElement="Flow_0v6pwqf">
-        <di:waypoint x="1897" y="290" />
-        <di:waypoint x="1957" y="290" />
+        <di:waypoint x="1967" y="290" />
+        <di:waypoint x="2027" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0dqug0r_di" bpmnElement="Flow_0dqug0r">
-        <di:waypoint x="1467" y="290" />
-        <di:waypoint x="1527" y="290" />
+        <di:waypoint x="1537" y="290" />
+        <di:waypoint x="1597" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0fghmqt_di" bpmnElement="Flow_0fghmqt">
-        <di:waypoint x="208" y="290" />
         <di:waypoint x="278" y="290" />
+        <di:waypoint x="348" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0coeih9_di" bpmnElement="Flow_0coeih9">
-        <di:waypoint x="378" y="290" />
-        <di:waypoint x="438" y="290" />
+        <di:waypoint x="448" y="290" />
+        <di:waypoint x="508" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0nq27w0_di" bpmnElement="Flow_0nq27w0">
-        <di:waypoint x="1737" y="290" />
-        <di:waypoint x="1797" y="290" />
+        <di:waypoint x="1807" y="290" />
+        <di:waypoint x="1867" y="290" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1727" y="272" width="65" height="14" />
+          <dc:Bounds x="1797" y="272" width="65" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ocsi68_di" bpmnElement="Flow_1ocsi68">
-        <di:waypoint x="1627" y="290" />
-        <di:waypoint x="1687" y="290" />
+        <di:waypoint x="1697" y="290" />
+        <di:waypoint x="1757" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0a79ens_di" bpmnElement="Flow_0a79ens">
-        <di:waypoint x="1712" y="315" />
-        <di:waypoint x="1712" y="418" />
-        <di:waypoint x="1957" y="418" />
+        <di:waypoint x="1782" y="315" />
+        <di:waypoint x="1782" y="418" />
+        <di:waypoint x="2027" y="418" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1718" y="386" width="67" height="27" />
+          <dc:Bounds x="1788" y="386" width="67" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0fh19mp_di" bpmnElement="Flow_0fh19mp">
-        <di:waypoint x="1712" y="265" />
-        <di:waypoint x="1712" y="148" />
-        <di:waypoint x="1797" y="148" />
+        <di:waypoint x="1782" y="265" />
+        <di:waypoint x="1782" y="148" />
+        <di:waypoint x="1867" y="148" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1721" y="156" width="55" height="27" />
+          <dc:Bounds x="1791" y="156" width="55" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08s0wt5_di" bpmnElement="Flow_08s0wt5">
-        <di:waypoint x="1847" y="108" />
-        <di:waypoint x="1847" y="88" />
-        <di:waypoint x="2100" y="88" />
-        <di:waypoint x="2100" y="108" />
+        <di:waypoint x="1967" y="148" />
+        <di:waypoint x="2060" y="148" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_02rr1ty_di" bpmnElement="Flow_02rr1ty">
-        <di:waypoint x="358" y="348" />
-        <di:waypoint x="358" y="368" />
-        <di:waypoint x="463" y="368" />
-        <di:waypoint x="463" y="315" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0d6n3x7_di" bpmnElement="Flow_0d6n3x7">
-        <di:waypoint x="2100" y="108" />
-        <di:waypoint x="2100" y="88" />
-        <di:waypoint x="1975" y="88" />
-        <di:waypoint x="1975" y="130" />
+        <di:waypoint x="428" y="348" />
+        <di:waypoint x="428" y="368" />
+        <di:waypoint x="533" y="368" />
+        <di:waypoint x="533" y="315" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_16e6f6v_di" bpmnElement="Flow_16e6f6v">
-        <di:waypoint x="488" y="290" />
-        <di:waypoint x="548" y="290" />
+        <di:waypoint x="558" y="290" />
+        <di:waypoint x="618" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1tw35xw_di" bpmnElement="Flow_1tw35xw">
-        <di:waypoint x="1307" y="290" />
-        <di:waypoint x="1367" y="290" />
+        <di:waypoint x="1377" y="290" />
+        <di:waypoint x="1437" y="290" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_1h2tjie_di" bpmnElement="Association_1h2tjie">
-        <di:waypoint x="319" y="250" />
-        <di:waypoint x="310" y="211" />
+        <di:waypoint x="389" y="250" />
+        <di:waypoint x="380" y="211" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_0p70jxz_di" bpmnElement="Association_0p70jxz">
-        <di:waypoint x="1456" y="250" />
-        <di:waypoint x="1494" y="211" />
+        <di:waypoint x="1526" y="250" />
+        <di:waypoint x="1564" y="211" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_loan_approval_intro_di" bpmnElement="Association_loan_approval_intro">
+        <di:waypoint x="260" y="272" />
+        <di:waypoint x="260" y="237" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0d6n3x7_di" bpmnElement="Flow_0d6n3x7">
+        <di:waypoint x="2160" y="148" />
+        <di:waypoint x="2212" y="148" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/solutions/bank-ai-loan-approval/AI Email Support Agent.bpmn
+++ b/solutions/bank-ai-loan-approval/AI Email Support Agent.bpmn
@@ -820,7 +820,7 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_human_control_end_di" bpmnElement="Flow_human_control_end">
-        <di:waypoint x="2143" y="418" />
+        <di:waypoint x="2213" y="418" />
         <di:waypoint x="2270" y="418" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08s0wt5_di" bpmnElement="Flow_08s0wt5">

--- a/solutions/bank-ai-loan-approval/test/src/test/resources/test-cases/AI Email Support Agent.test.json
+++ b/solutions/bank-ai-loan-approval/test/src/test/resources/test-cases/AI Email Support Agent.test.json
@@ -3,7 +3,7 @@
   "testCases": [
     {
       "name": "happy path - agent resolves successfully, case solved",
-      "description": "Customer email received. Past conversations fetched. Agent handles request. Agent-as-a-Judge rates AGENT_SUCCESS. Final answer sent. Human reviews. Case solved.",
+      "description": "Customer email received. Past conversations fetched. Agent handles request. Agent-as-a-Judge rates AGENT_SUCCESS. Human reviews resolution. Final answer sent. Case solved.",
       "instructions": [
         {
           "type": "CREATE_PROCESS_INSTANCE",
@@ -64,13 +64,19 @@
           }
         },
         {
-          "type": "COMPLETE_JOB",
-          "jobSelector": { "elementId": "Activity_0d9av47" },
-          "variables": {}
+          "type": "ASSERT_ELEMENT_INSTANCES",
+          "processInstanceSelector": { "processDefinitionId": "Process_0j5qzil" },
+          "elementSelectors": [{ "elementId": "Activity_1647ldd" }],
+          "state": "IS_ACTIVE"
         },
         {
           "type": "COMPLETE_USER_TASK",
           "userTaskSelector": { "elementId": "Activity_1647ldd" },
+          "variables": {}
+        },
+        {
+          "type": "COMPLETE_JOB",
+          "jobSelector": { "elementId": "Activity_0d9av47" },
           "variables": {}
         },
         {
@@ -216,13 +222,19 @@
           }
         },
         {
-          "type": "COMPLETE_JOB",
-          "jobSelector": { "elementId": "Activity_0d9av47" },
-          "variables": {}
+          "type": "ASSERT_ELEMENT_INSTANCES",
+          "processInstanceSelector": { "processDefinitionId": "Process_0j5qzil" },
+          "elementSelectors": [{ "elementId": "Activity_1647ldd" }],
+          "state": "IS_ACTIVE"
         },
         {
           "type": "COMPLETE_USER_TASK",
           "userTaskSelector": { "elementId": "Activity_1647ldd" },
+          "variables": {}
+        },
+        {
+          "type": "COMPLETE_JOB",
+          "jobSelector": { "elementId": "Activity_0d9av47" },
           "variables": {}
         },
         {


### PR DESCRIPTION
## Summary

Fixes two issues reported in Slack ([thread](https://camunda.slack.com/archives/C05S2QM684U/p1776068928897879)) with the AI Email Support Agent blueprint.

**Logic fix**: Swapped \"Review case resolution\" and \"Final answer to customer\" so the human reviewer approves the agent's response before it is sent to the customer. The previous order inverted the human-in-the-loop step.

**Layout and DI fixes**:
- Moved \"Case solved\" end event to the right of both tasks; resolved overlapping sequence flow edges in that area
- Added missing `<bpmndi:BPMNLabel />` on unnamed join gateway `Gateway_0kp1fqr` — this element was omitted by the modeling tool for unnamed gateways, which surfaced a serialization bug
- Added explicit XOR join gateway (`Gateway_join_specialist`) before \"Specialist answered\" inside the ad-hoc sub-process to fix a `fake-join` lint violation
- Added explicit end event downstream of the escalation throw to satisfy `no-implicit-end`
- Added `BPMNShape`/`BPMNEdge` for `TextAnnotation_loan_approval_intro` and its association, which were in the process XML but missing from the diagram (`no-bpmndi` errors)
- Consolidated three duplicate escalation elements and two duplicate error elements; removed unused `Message_0fr5ip9`

Result: 0 bpmnlint errors, 0 warnings (down from 2 errors, 8 warnings).

**Test fix**: Updated test cases to complete the user task (\"Review case resolution\") before the service task (\"Final answer to customer\") to match the corrected flow order.

## Test plan

- [x] `npx bpmnlint --config .bpmnlintrc "solutions/bank-ai-loan-approval/AI Email Support Agent.bpmn"` — exits 0, 0 errors, 0 warnings
- [x] Diagram flow reads left-to-right: Review case resolution → Final answer to customer → Case solved
- [x] \"Case solved\" end event is rightmost element in the top path
- [x] Camunda Modeler shows \"No problems found\"
- [ ] `mvn test` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)