### PR TITLE
feat(schema): introduce group-level process variable schema system

### DIFF
--- a/.github/workflows/variable-schema.yml
+++ b/.github/workflows/variable-schema.yml
@@ -65,7 +65,7 @@ jobs:
             --spec=draft2020 \
             -s schema/process-variables.meta-schema.json \
             -d schema/process-variables.meta-schema.json \
-            --strict=false || true
+            --strict=false
           echo "Meta-schema structural check complete."
 
   check:

--- a/.github/workflows/variable-schema.yml
+++ b/.github/workflows/variable-schema.yml
@@ -59,14 +59,15 @@ jobs:
       - run: npm ci --legacy-peer-deps
       - name: Install ajv-cli
         run: npm install -g ajv-cli
-      - name: Validate meta-schema structure
+      - name: Validate group schemas against meta-schema
         run: |
           ajv validate \
             --spec=draft2020 \
             -s schema/process-variables.meta-schema.json \
-            -d schema/process-variables.meta-schema.json \
+            -d solutions/variables.schema.json \
+            -d quick-start/variables.schema.json \
             --strict=false
-          echo "Meta-schema structural check complete."
+          echo "Schema validation complete."
 
   check:
     name: Check ${{ matrix.group }}

--- a/.github/workflows/variable-schema.yml
+++ b/.github/workflows/variable-schema.yml
@@ -1,0 +1,163 @@
+name: Variable Schema
+
+on:
+  pull_request:
+    paths:
+      - '**/*.bpmn'
+      - '**/*.dmn'
+      - '**/*.form'
+      - '**/*.test.json'
+      - 'solutions/variables.schema.json'
+      - 'quick-start/variables.schema.json'
+      - 'schema/**'
+      - '.variable-schema.config.json'
+      - 'tools/schema/**'
+
+jobs:
+  detect:
+    name: Detect changed groups
+    runs-on: ubuntu-latest
+    outputs:
+      groups: ${{ steps.detect.outputs.groups }}
+      schema-changed: ${{ steps.detect.outputs.schema-changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect which groups changed
+        id: detect
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.sha }}"
+          CHANGED=$(git diff --name-only "$BASE"..."$HEAD")
+
+          GROUPS=()
+          echo "$CHANGED" | grep -qE '^solutions/' && GROUPS+=("solutions")
+          echo "$CHANGED" | grep -qE '^quick-start/' && GROUPS+=("quick-start")
+
+          SCHEMA_CHANGED=false
+          echo "$CHANGED" | grep -qE '^schema/' && SCHEMA_CHANGED=true
+
+          if [ ${#GROUPS[@]} -eq 0 ]; then
+            echo "groups=[]" >> "$GITHUB_OUTPUT"
+          else
+            JSON=$(printf '%s\n' "${GROUPS[@]}" | jq -R . | jq -cs .)
+            echo "groups=$JSON" >> "$GITHUB_OUTPUT"
+          fi
+          echo "schema-changed=$SCHEMA_CHANGED" >> "$GITHUB_OUTPUT"
+
+  validate-meta-schema:
+    name: Validate meta-schema
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci --legacy-peer-deps
+      - name: Install ajv-cli
+        run: npm install -g ajv-cli
+      - name: Validate meta-schema structure
+        run: |
+          ajv validate \
+            --spec=draft2020 \
+            -s schema/process-variables.meta-schema.json \
+            -d schema/process-variables.meta-schema.json \
+            --strict=false || true
+          echo "Meta-schema structural check complete."
+
+  check:
+    name: Check ${{ matrix.group }}
+    needs: detect
+    if: needs.detect.outputs.groups != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ${{ fromJson(needs.detect.outputs.groups) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci --legacy-peer-deps
+
+      - name: Validate group schema against meta-schema
+        if: ${{ hashFiles(format('{0}/variables.schema.json', matrix.group)) != '' }}
+        run: |
+          npx ajv validate \
+            --spec=draft2020 \
+            -s schema/process-variables.meta-schema.json \
+            -d "${{ matrix.group }}/variables.schema.json" \
+            --strict=false
+
+      - name: Check for unregistered variables
+        run: |
+          node tools/schema/extract-variables.mjs \
+            --check \
+            --group "${{ matrix.group }}"
+
+      - name: Lint naming convention
+        run: |
+          node tools/schema/lint-naming.mjs \
+            --group "${{ matrix.group }}"
+
+  dead-scan:
+    name: Dead variable scan (${{ matrix.group }})
+    needs: [detect, check]
+    if: needs.detect.outputs.groups != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ${{ fromJson(needs.detect.outputs.groups) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci --legacy-peer-deps
+      - name: Scan for dead variables
+        run: |
+          node tools/schema/extract-variables.mjs \
+            --dead \
+            --group "${{ matrix.group }}"
+
+  similarity:
+    name: Variable similarity scan
+    needs: [detect, check]
+    if: needs.detect.outputs.groups != '[]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci --legacy-peer-deps
+      - name: Find similar variables (advisory)
+        run: node tools/schema/find-similar-variables.mjs
+
+  cascade-warning:
+    name: Cascade impact warning
+    needs: detect
+    if: needs.detect.outputs.schema-changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Report schema cascade impact
+        run: |
+          echo "## Shared Schema Change" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The \`schema/\` directory changed in this PR. Both group schemas reference the meta-schema." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Affected schemas:" >> $GITHUB_STEP_SUMMARY
+          for f in solutions/variables.schema.json quick-start/variables.schema.json; do
+            [ -f "$f" ] && echo "- \`$f\`" >> $GITHUB_STEP_SUMMARY
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Review both group schemas and run full check before merging." >> $GITHUB_STEP_SUMMARY

--- a/.variable-schema.config.json
+++ b/.variable-schema.config.json
@@ -1,0 +1,8 @@
+{
+  "$comment": "Repo-level defaults for the process variable schema system. Per-solution variables.schema.json metadata may override scope and owner.",
+  "convention": "camelCase",
+  "scope": "process",
+  "enforceNaming": false,
+  "similarityTier": "levenshtein",
+  "cdmEndpoint": null
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# Claude Code — Project Instructions
+
+## Autonomy
+
+Claude operates in **delegated mode** for all tasks in this repository unless the user explicitly asks for guided or report-only behaviour.
+
+In delegated mode:
+- Apply all critical and important fixes automatically without asking for confirmation.
+- Propose and apply changes to BPMN files, test JSON, schemas, CI config, and tooling directly.
+- Commit changes when a logical unit of work is complete, following the commit conventions below.
+- Run `npx bpmnlint --config .bpmnlintrc <file>` after any BPMN edit and fix all errors before opening in Camunda Modeler.
+- Run `mvn test` (or flag that it should run in CI) after test file edits.
+
+Ask before acting only for:
+- Force-pushing or resetting branches.
+- Deleting files that may contain unreplaced work.
+- Opening or merging pull requests.
+- Any action that affects systems outside this repository (email, Slack, external APIs).
+
+## Process variable schema
+
+There are two group-level schemas, each covering all processes in their group:
+- `solutions/variables.schema.json` — vocabulary for all solution processes
+- `quick-start/variables.schema.json` — vocabulary for all quick-start processes
+
+Both point `$schema` at `../schema/process-variables.meta-schema.json`.
+
+The schema system is described in full in GitHub issue #95. Claude maintains it autonomously:
+
+- **Add a new process variable:** add it to the appropriate group schema with `title`, `type`, `description`, and `examples`. For object variables add `properties`.
+- **Check on PR:** run `--check --group solutions|quick-start` and `--dead --group solutions|quick-start`; fix unregistered variable errors; post dead-variable candidates as PR comments.
+- **Naming violations:** fix in BPMN output targets, DMN outputs, form keys, and test JSON in one commit (order: form keys → BPMN → DMN → test JSON). Update the schema entry name to match.
+- **Structural similarity:** run `node tools/schema/find-similar-variables.mjs`; evaluate whether cross-group consolidation into `schema/$defs/` is warranted at Jaccard ≥ 0.70.
+- **Cascade:** when `schema/` changes, both group schemas are affected; run both checks before merging.
+- **`enforceNaming`:** set to `true` in `.variable-schema.config.json` after issue #96 (snake_case migration) is merged.
+
+## BPMN and process changes
+
+- Run `npx bpmnlint --config .bpmnlintrc <file>` after every BPMN edit; fix all errors before committing.
+- Do not rename BPMN element `id` attributes — they break test references.
+- Only propose `name` attribute changes and test JSON updates.
+- After fixing BPMN names, open in Camunda Modeler: `open -a "Camunda Modeler" <file>`.
+
+## Commit conventions
+
+- Format: `<type>(<scope>): <short description>`
+- Types: `feat`, `fix`, `chore`, `docs`, `test`, `ci`
+- Scope: solution name or tool area (e.g. `absence-request`, `schema`, `ci`)
+- Always append `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
+
+## CI
+
+Two workflows:
+- `bpmn-lint.yml` — runs on BPMN/DMN changes; must pass before merge.
+- `variable-schema.yml` — runs on diagram, form, test, and schema changes; check and naming-lint jobs must pass; dead-scan and similarity are advisory.
+- `test-suites.yml` — runs Maven tests for solutions with a `test/pom.xml`.
+
+## Tools available
+
+| Tool | Command |
+|------|---------|
+| Extract variables | `node tools/schema/extract-variables.mjs --extract\|--check\|--dead --group solutions\|quick-start` |
+| Lint naming | `node tools/schema/lint-naming.mjs --group solutions\|quick-start` |
+| Find similar variables | `node tools/schema/find-similar-variables.mjs` |
+| BPMN lint | `npx bpmnlint --config .bpmnlintrc <file>` |
+| Render screenshot | `node /Users/eric.lundberg/GitHub/camunda-ai-dev-kit/tools/camunda-viewer/screenshot.mjs <file>` |

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS — process variable schema
+# Changes to the schema infrastructure and either group vocabulary require review.
+
+schema/                           @HanselIdes
+solutions/variables.schema.json   @HanselIdes
+quick-start/variables.schema.json @HanselIdes
+tools/schema/                     @HanselIdes
+.variable-schema.config.json      @HanselIdes

--- a/quick-start/variables.schema.json
+++ b/quick-start/variables.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../schema/process-variables.meta-schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/camunda-8-tutorials/main/schema/process-variables.meta-schema.json",
   "title": "Camunda 8 Tutorials — Quick Start Process Variables",
   "metadata": {
     "convention": "camelCase",

--- a/quick-start/variables.schema.json
+++ b/quick-start/variables.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../schema/process-variables.meta-schema.json",
+  "title": "Camunda 8 Tutorials — Quick Start Process Variables",
+  "metadata": {
+    "convention": "camelCase",
+    "scope": "process",
+    "owner": "@HanselIdes"
+  },
+  "variables": {
+    "meal": {
+      "title": "Meal choice",
+      "type": "string",
+      "description": "The meal selected by the user on the human task form. Represents the output of the 'Decide what's for dinner' decision.",
+      "examples": ["pizza"]
+    }
+  }
+}

--- a/schema/process-variables.meta-schema.json
+++ b/schema/process-variables.meta-schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/camunda/camunda-8-tutorials/main/schema/process-variables.meta-schema.json",
+  "title": "Process Variable Schema — meta-schema",
+  "description": "Validates the structure of schema/process-variables.json. Enforces required fields on every variable entry, fully-typed properties on object variables, items schema on array variables, and at least one example on every entry.",
+  "type": "object",
+  "required": ["$schema", "variables"],
+  "properties": {
+    "$schema": {
+      "const": "https://raw.githubusercontent.com/camunda/camunda-8-tutorials/main/schema/process-variables.meta-schema.json"
+    },
+    "title": { "type": "string" },
+    "description": { "type": "string" },
+    "metadata": {
+      "type": "object",
+      "description": "Generation-time configuration for this schema file.",
+      "properties": {
+        "scope": {
+          "type": "string",
+          "enum": ["process", "all"],
+          "description": "Controls whether sub-process-scoped variables are included. 'process' = top-level only; 'all' = all scopes."
+        },
+        "generatedAt": { "type": "string", "format": "date-time" },
+        "processIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "$defs": {
+      "type": "object",
+      "description": "Reusable complex type definitions referenced via $ref. Each entry must satisfy the same shape requirements as a variable entry.",
+      "additionalProperties": { "$ref": "#/$defs/VariableEntry" }
+    },
+    "variables": {
+      "type": "object",
+      "description": "Flat vocabulary of all process-scope variables. One entry per logical variable name. Dead variables remain here with description prefixed 'DEAD - <date>.'",
+      "additionalProperties": { "$ref": "#/$defs/VariableEntry" }
+    }
+  },
+  "$defs": {
+    "VariableEntry": {
+      "type": "object",
+      "description": "A single variable in the process vocabulary, or a reusable type definition in $defs.",
+      "required": ["title", "description", "examples"],
+      "anyOf": [
+        { "required": ["type"] },
+        { "required": ["$ref"] }
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Short human-readable label for the variable.",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "description": "Business-level description. Dead variables must begin with 'DEAD - <date>.' followed by what superseded them.",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "description": "JSON Schema primitive or structural type.",
+          "enum": ["string", "number", "integer", "boolean", "object", "array", "null"]
+        },
+        "$ref": {
+          "type": "string",
+          "description": "Reference to a reusable type defined in $defs."
+        },
+        "examples": {
+          "type": "array",
+          "description": "At least one representative example value showing the realistic shape of the variable.",
+          "minItems": 1
+        },
+        "enum": {
+          "type": "array",
+          "description": "Closed set of valid values. Use when the variable is constrained to a fixed vocabulary.",
+          "minItems": 2,
+          "uniqueItems": true
+        },
+        "format": {
+          "type": "string",
+          "description": "Well-known string format annotation.",
+          "enum": ["date", "date-time", "time", "email", "uri", "uuid", "ipv4", "ipv6"]
+        },
+        "required": {
+          "type": "array",
+          "description": "Mandatory property names for object variables.",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "object",
+          "description": "Sub-property definitions for object variables. Every property must be fully typed and documented.",
+          "additionalProperties": { "$ref": "#/$defs/PropertyEntry" }
+        },
+        "items": {
+          "description": "Schema for the elements of an array variable. Either a full inline schema or a $ref.",
+          "oneOf": [
+            { "$ref": "#/$defs/PropertyEntry" },
+            {
+              "type": "object",
+              "required": ["$ref"],
+              "properties": { "$ref": { "type": "string" } },
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "if": {
+        "properties": { "type": { "const": "object" } },
+        "required": ["type"]
+      },
+      "then": {
+        "required": ["properties"]
+      },
+      "else": {
+        "if": {
+          "properties": { "type": { "const": "array" } },
+          "required": ["type"]
+        },
+        "then": {
+          "required": ["items"]
+        }
+      }
+    },
+    "PropertyEntry": {
+      "type": "object",
+      "description": "A named property within an object variable or $defs type. Must be fully typed and documented at every depth.",
+      "required": ["type", "description", "examples"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["string", "number", "integer", "boolean", "object", "array", "null"]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "examples": {
+          "type": "array",
+          "minItems": 1
+        },
+        "enum": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true
+        },
+        "format": {
+          "type": "string",
+          "enum": ["date", "date-time", "time", "email", "uri", "uuid", "ipv4", "ipv6"]
+        },
+        "required": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "object",
+          "description": "Nested sub-properties for object-typed properties. Recursively enforces the same shape.",
+          "additionalProperties": { "$ref": "#/$defs/PropertyEntry" }
+        },
+        "items": {
+          "description": "Schema for array-typed properties.",
+          "oneOf": [
+            { "$ref": "#/$defs/PropertyEntry" },
+            {
+              "type": "object",
+              "required": ["$ref"],
+              "properties": { "$ref": { "type": "string" } },
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "if": {
+        "properties": { "type": { "const": "object" } },
+        "required": ["type"]
+      },
+      "then": {
+        "required": ["properties"]
+      },
+      "else": {
+        "if": {
+          "properties": { "type": { "const": "array" } },
+          "required": ["type"]
+        },
+        "then": {
+          "required": ["items"]
+        }
+      }
+    }
+  }
+}

--- a/solutions/variables.schema.json
+++ b/solutions/variables.schema.json
@@ -72,6 +72,7 @@
         "context": {
           "type": "object",
           "description": "Execution metrics and conversation state.",
+          "examples": [{"state": "READY", "metrics": {"modelCalls": 1}}],
           "properties": {
             "state": {
               "type": "string",

--- a/solutions/variables.schema.json
+++ b/solutions/variables.schema.json
@@ -3,7 +3,7 @@
   "title": "Camunda 8 Tutorials — Solutions Process Variables",
   "metadata": {
     "convention": "camelCase",
-    "scope": "--extract",
+    "scope": "process",
     "owner": "@HanselIdes"
   },
   "variables": {

--- a/solutions/variables.schema.json
+++ b/solutions/variables.schema.json
@@ -84,6 +84,7 @@
             "metrics": {
               "type": "object",
               "description": "Token usage counters.",
+              "examples": [{"modelCalls": 1, "tokenUsage": {"inputTokenCount": 100, "outputTokenCount": 50}}],
               "properties": {
                 "modelCalls": {
                   "type": "integer",
@@ -95,6 +96,7 @@
                 "tokenUsage": {
                   "type": "object",
                   "description": "Input and output token counts.",
+                  "examples": [{"inputTokenCount": 100, "outputTokenCount": 50}],
                   "properties": {
                     "inputTokenCount": {
                       "type": "integer",

--- a/solutions/variables.schema.json
+++ b/solutions/variables.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../schema/process-variables.meta-schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/camunda-8-tutorials/main/schema/process-variables.meta-schema.json",
   "title": "Camunda 8 Tutorials — Solutions Process Variables",
   "metadata": {
     "convention": "camelCase",

--- a/solutions/variables.schema.json
+++ b/solutions/variables.schema.json
@@ -1,0 +1,1005 @@
+{
+  "$schema": "../schema/process-variables.meta-schema.json",
+  "title": "Camunda 8 Tutorials — Solutions Process Variables",
+  "metadata": {
+    "convention": "camelCase",
+    "scope": "--extract",
+    "owner": "@HanselIdes"
+  },
+  "variables": {
+    "absenceEndDate": {
+      "title": "Absence end date",
+      "type": "string",
+      "format": "date",
+      "description": "Last day of the requested absence period, inclusive. Submitted by the employee on the request form.",
+      "examples": [
+        "2024-08-16"
+      ]
+    },
+    "absenceLogged": {
+      "title": "Absence logged",
+      "type": "boolean",
+      "description": "Confirmation flag set by the HR system task after successfully recording the approved absence.",
+      "examples": [
+        true
+      ]
+    },
+    "absenceStartDate": {
+      "title": "Absence start date",
+      "type": "string",
+      "format": "date",
+      "description": "First day of the requested absence period. Submitted by the employee on the request form.",
+      "examples": [
+        "2024-08-12"
+      ]
+    },
+    "additional_comments": {
+      "title": "Additional comments",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/event-registration (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "address_1": {
+      "title": "Address 1",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "address_2": {
+      "title": "Address 2",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "agent": {
+      "title": "Agent context",
+      "type": "object",
+      "description": "Full agent execution context returned by the AI agent job worker after the ad-hoc sub-process completes.",
+      "properties": {
+        "responseText": {
+          "type": "string",
+          "description": "Final text response produced by the agent.",
+          "examples": [
+            "Your loan application is under review."
+          ]
+        },
+        "context": {
+          "type": "object",
+          "description": "Execution metrics and conversation state.",
+          "properties": {
+            "state": {
+              "type": "string",
+              "description": "Agent state at completion.",
+              "examples": [
+                "READY"
+              ]
+            },
+            "metrics": {
+              "type": "object",
+              "description": "Token usage counters.",
+              "properties": {
+                "modelCalls": {
+                  "type": "integer",
+                  "description": "Number of model invocations.",
+                  "examples": [
+                    1
+                  ]
+                },
+                "tokenUsage": {
+                  "type": "object",
+                  "description": "Input and output token counts.",
+                  "properties": {
+                    "inputTokenCount": {
+                      "type": "integer",
+                      "description": "Tokens consumed as input.",
+                      "examples": [
+                        100
+                      ]
+                    },
+                    "outputTokenCount": {
+                      "type": "integer",
+                      "description": "Tokens produced as output.",
+                      "examples": [
+                        50
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "examples": [
+        {
+          "responseText": "Your loan application is under review.",
+          "context": {
+            "state": "READY",
+            "metrics": {
+              "modelCalls": 1,
+              "tokenUsage": {
+                "inputTokenCount": 100,
+                "outputTokenCount": 50
+              }
+            }
+          }
+        }
+      ]
+    },
+    "amount": {
+      "title": "Amount",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "annual_salary": {
+      "title": "Annual salary",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "answer": {
+      "title": "Answer",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/enforcing-sla (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "approvalResult": {
+      "title": "Approval result",
+      "type": "string",
+      "description": "Line manager's decision on the absence request. Drives the post-approval gateway routing.",
+      "enum": [
+        "approved",
+        "rejected",
+        "clarificationNeeded"
+      ],
+      "examples": [
+        "approved"
+      ]
+    },
+    "approve_loan": {
+      "title": "Approve loan",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "assignedLineManager": {
+      "title": "Assigned line manager",
+      "type": "string",
+      "description": "Display name of the line manager assigned to approve this absence request, resolved from the DMN decision.",
+      "examples": [
+        "John"
+      ]
+    },
+    "city": {
+      "title": "City",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "clarificationCommentEmployee": {
+      "title": "Clarification comment (employee)",
+      "type": "string",
+      "description": "Employee's written response during the clarification loop.",
+      "examples": [
+        "I need to attend a family event on those dates."
+      ]
+    },
+    "clarificationCommentLineManager": {
+      "title": "Clarification comment (line manager)",
+      "type": "string",
+      "description": "Line manager's note when requesting clarification before making a final decision.",
+      "examples": [
+        "Please confirm whether you have arranged cover for those days."
+      ]
+    },
+    "company": {
+      "title": "Company",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/event-registration (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "country": {
+      "title": "Country",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "current_employer": {
+      "title": "Current employer",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "custom_interest_rate": {
+      "title": "Custom interest rate",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "customer_inquiry": {
+      "title": "Customer inquiry",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-intelligent-routing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "customer_message": {
+      "title": "Customer message",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-intelligent-routing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "customerProofText": {
+      "title": "Customer Proof Text",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-customer-complaint-dispute-handling (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "customExpenseType": {
+      "title": "Custom Expense Type",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "damage": {
+      "title": "Damage",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/insurance-personal-property-damage-claim-handling (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "date_of_birth": {
+      "title": "Date of birth",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "date_of_purchase": {
+      "title": "Date of purchase",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/insurance-personal-property-damage-claim-handling (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "decision": {
+      "title": "Agent-as-a-Judge decision",
+      "type": "string",
+      "description": "Evaluation outcome from the Agent-as-a-Judge task. Drives routing after quality assessment.",
+      "enum": [
+        "AGENT_SUCCESS",
+        "AGENT_SUBOPTIMAL"
+      ],
+      "examples": [
+        "AGENT_SUCCESS"
+      ]
+    },
+    "deductible": {
+      "title": "Deductible",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/insurance-personal-property-damage-claim-handling (sources: bpmn-output, dmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "department": {
+      "title": "Department",
+      "type": "string",
+      "description": "The employee's department. Used as input to the Department Line Manager DMN decision.",
+      "examples": [
+        "sales"
+      ]
+    },
+    "department_line_manager": {
+      "title": "Department line manager (legacy)",
+      "type": "string",
+      "description": "Output of the Department Line Manager DMN decision. snake_case — migration to camelCase pending (issue #96). Superseded by assignedLineManager after the mapping step.",
+      "examples": [
+        "John"
+      ]
+    },
+    "disputeDetails": {
+      "title": "Dispute Details",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-customer-complaint-dispute-handling (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "email": {
+      "title": "Email",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/event-registration, solutions/bank-loan-origination-and-processing, solutions/expense-reimbursement (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "emailOk": {
+      "title": "Email Ok",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-agent-chat-with-tools (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "employeeName": {
+      "title": "Employee name",
+      "type": "string",
+      "description": "Full name of the employee submitting the absence request.",
+      "examples": [
+        "Alice Smith"
+      ]
+    },
+    "expenseAmount": {
+      "title": "Expense Amount",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "expenseDate": {
+      "title": "Expense Date",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "expensePurpose": {
+      "title": "Expense Purpose",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "expenseType": {
+      "title": "Expense Type",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "feedback": {
+      "title": "Feedback",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-intelligent-routing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "financeReviewOutcome": {
+      "title": "Finance Review Outcome",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: bpmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "first_name": {
+      "title": "First name",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/event-registration, solutions/bank-loan-origination-and-processing (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "firstName": {
+      "title": "First Name",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "folderId": {
+      "title": "Folder Id",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ci-cd (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "followUpDocuments": {
+      "title": "Follow Up Documents",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-agent-chat-with-mcp, solutions/ai-agent-chat-with-tools (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "followUpInput": {
+      "title": "Follow Up Input",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-agent-chat-with-mcp, solutions/ai-agent-chat-with-tools (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "fraud_rating_confidence_score": {
+      "title": "Fraud rating confidence score",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-customer-complaint-dispute-handling (sources: dmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "fraud_rating_score": {
+      "title": "Fraud rating score",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-customer-complaint-dispute-handling (sources: dmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "future_notifications": {
+      "title": "Future notifications",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/event-registration (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "gitlabBaseUrl": {
+      "title": "Gitlab Base Url",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ci-cd (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "gitlabBranch": {
+      "title": "Gitlab Branch",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ci-cd (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "gitlabProjectId": {
+      "title": "Gitlab Project Id",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ci-cd (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "hasCarDamage": {
+      "title": "Has Car Damage",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/car-rental-booking-process (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "identified_issues": {
+      "title": "Identified issues",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-ai-loan-approval (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "incident_description": {
+      "title": "Incident description",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/insurance-personal-property-damage-claim-handling (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "inputDocuments": {
+      "title": "Input Documents",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-agent-chat-with-mcp, solutions/ai-agent-chat-with-tools (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "inputText": {
+      "title": "Input Text",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-agent-chat-with-mcp, solutions/ai-agent-chat-with-tools (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "inquiry": {
+      "title": "Inquiry",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/enforcing-sla (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "interestRate": {
+      "title": "Interest Rate",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: dmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "isAlternativeAccepted": {
+      "title": "Is Alternative Accepted",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/car-rental-booking-process (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "isApproved": {
+      "title": "Is Approved",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/insurance-personal-property-damage-claim-handling (sources: bpmn-output, dmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "isCarReady": {
+      "title": "Is Car Ready",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/car-rental-booking-process (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "isHighFraudRatingConfidence": {
+      "title": "Is High Fraud Rating Confidence",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-customer-complaint-dispute-handling (sources: bpmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "isLoanEligible": {
+      "title": "Is Loan Eligible",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: dmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "isRefund": {
+      "title": "Is Refund",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-customer-complaint-dispute-handling (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "isTradeAccepted": {
+      "title": "Is Trade Accepted",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/capital-market-exception-processing (sources: dmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "item": {
+      "title": "Item",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/insurance-personal-property-damage-claim-handling (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "key": {
+      "title": "Key",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/enforcing-sla (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "knowledgeBaseDecision": {
+      "title": "Knowledge base decision",
+      "type": "string",
+      "description": "Whether the knowledge base query returned a usable answer. Gates the loop-back branch.",
+      "enum": [
+        "yes",
+        "no"
+      ],
+      "examples": [
+        "yes"
+      ]
+    },
+    "last_name": {
+      "title": "Last name",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/event-registration, solutions/bank-loan-origination-and-processing (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "lastName": {
+      "title": "Last Name",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "loan": {
+      "title": "Loan",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "maker": {
+      "title": "Maker",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/insurance-personal-property-damage-claim-handling (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "managerReviewOutcome": {
+      "title": "Manager Review Outcome",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: bpmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "metrics_inputTokenCount": {
+      "title": "Metrics input Token Count",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-ai-loan-approval (sources: bpmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "metrics_modelCalls": {
+      "title": "Metrics model Calls",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-ai-loan-approval (sources: bpmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "metrics_outputTokenCount": {
+      "title": "Metrics output Token Count",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-ai-loan-approval (sources: bpmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "milestoneLists": {
+      "title": "Milestone Lists",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ci-cd (sources: bpmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "mobile": {
+      "title": "Mobile",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "model": {
+      "title": "Model",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/insurance-personal-property-damage-claim-handling (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "newBranchName": {
+      "title": "New Branch Name",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ci-cd (sources: bpmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "news_source": {
+      "title": "News source",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/event-registration (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "news_source_alternative": {
+      "title": "News source alternative",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/event-registration (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "operatorFeedback": {
+      "title": "Operator Feedback",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-agent-chat-with-tools (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "personal_property": {
+      "title": "Personal property",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/insurance-personal-property-damage-claim-handling (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "phone": {
+      "title": "Phone",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "phone_number": {
+      "title": "Phone number",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/event-registration (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "policy": {
+      "title": "Absence policy",
+      "type": "string",
+      "description": "The absence policy applicable to this request, selected by the employee on the request form.",
+      "examples": [
+        "annual-leave"
+      ]
+    },
+    "price_at_purchase": {
+      "title": "Price at purchase",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/insurance-personal-property-damage-claim-handling (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "qaSuccessfulCheck": {
+      "title": "Qa Successful Check",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ci-cd (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "reasoning": {
+      "title": "Reasoning",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-ai-loan-approval (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "rejectionReason": {
+      "title": "Rejection reason",
+      "type": "string",
+      "description": "Line manager's explanation when the absence request is declined.",
+      "examples": [
+        "Insufficient cover available during that period."
+      ]
+    },
+    "reply": {
+      "title": "Reply",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/enforcing-sla (sources: bpmn-output, form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "requestComment": {
+      "title": "Request comment",
+      "type": "string",
+      "description": "Optional free-text note from the employee explaining the reason for the absence request.",
+      "examples": [
+        "Annual holiday with family."
+      ]
+    },
+    "requestDetails": {
+      "title": "Request Details",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-ai-loan-approval (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "responseToRequest": {
+      "title": "Response To Request",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-ai-loan-approval (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "reviewOutcome": {
+      "title": "Review Outcome",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "route": {
+      "title": "Route",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-intelligent-routing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "sanitizedFilePath": {
+      "title": "Sanitized File Path",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ci-cd (sources: bpmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "sendToUnderwriter": {
+      "title": "Send To Underwriter",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: dmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "ssn": {
+      "title": "Ssn",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "state": {
+      "title": "State",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "supervisorEmail": {
+      "title": "Supervisor Email",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "taking_full_control": {
+      "title": "Taking full control (legacy)",
+      "type": "boolean",
+      "description": "Flag set when the human operator takes over the case from the AI agent. snake_case — migration to camelCase pending (issue #96).",
+      "examples": [
+        false
+      ]
+    },
+    "tenure": {
+      "title": "Tenure",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "toolCallAllowed": {
+      "title": "Tool Call Allowed",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-agent-chat-with-mcp (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "toolCallResult": {
+      "title": "Tool Call Result",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-agent-chat-with-mcp, solutions/ai-agent-chat-with-tools (sources: bpmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "toolResult": {
+      "title": "Tool Result",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-ai-loan-approval (sources: bpmn-output)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "travelEnd": {
+      "title": "Travel End",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "travelLocation": {
+      "title": "Travel Location",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "travelStart": {
+      "title": "Travel Start",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/expense-reimbursement (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "userSatisfied": {
+      "title": "User Satisfied",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/ai-agent-chat-with-mcp, solutions/ai-agent-chat-with-tools (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "vendorProofText": {
+      "title": "Vendor Proof Text",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-customer-complaint-dispute-handling (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    },
+    "zip_code": {
+      "title": "Zip code",
+      "type": "string",
+      "description": "{TODO: business description} — used in: solutions/bank-loan-origination-and-processing (sources: form-key)",
+      "examples": [
+        "{TODO: example value}"
+      ]
+    }
+  }
+}

--- a/tools/schema/extract-variables.mjs
+++ b/tools/schema/extract-variables.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * extract-variables.mjs — Process variable extraction and schema validation tool.
+ *
+ * Operates on two group-level schemas:
+ *   solutions/variables.schema.json  — vocabulary for all processes under solutions/
+ *   quick-start/variables.schema.json — vocabulary for all processes under quick-start/
+ *
+ * Usage:
+ *   node tools/schema/extract-variables.mjs --extract --group solutions [--write]
+ *   node tools/schema/extract-variables.mjs --check   --group solutions
+ *   node tools/schema/extract-variables.mjs --dead    --group solutions
+ *   node tools/schema/extract-variables.mjs --check   --file solutions/absence-request/Absence\ Request.bpmn
+ *
+ * Modes:
+ *   --extract   Scan all diagram/form files in the group. Output a draft variables.schema.json.
+ *               With --write: write the file to <group>/variables.schema.json.
+ *   --check     Report variables present in diagrams but absent from the group schema.
+ *               Emits GitHub Actions annotations; exits 1 if violations found.
+ *   --dead      Report schema entries absent from all diagram files in the group. Advisory, exits 0.
+ *
+ * Flags:
+ *   --group solutions|quick-start   Target group.
+ *   --file <path>                   Run --check on a single changed file (derives group automatically).
+ *   --scope process|all             Override scope from config. Default: "process".
+ *   --write                         (--extract only) Write draft to <group>/variables.schema.json.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { resolve, join, relative, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { glob } from './lib/glob.mjs';
+import { parseBpmn } from './lib/bpmn.mjs';
+import { parseDmn } from './lib/dmn.mjs';
+import { parseForm } from './lib/form.mjs';
+import { parseTestJson } from './lib/test-json.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../..');
+
+// ── argument parsing ────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const mode = args.includes('--extract') ? 'extract'
+           : args.includes('--check')   ? 'check'
+           : args.includes('--dead')    ? 'dead'
+           : null;
+
+if (!mode) {
+  console.error('Usage: extract-variables.mjs --extract|--check|--dead --group solutions|quick-start');
+  process.exit(1);
+}
+
+const writeFlag = args.includes('--write');
+const scopeArg  = args[args.indexOf('--scope') + 1] ?? null;
+
+// Derive group from --group flag or --file path
+let group;
+const groupArg = args[args.indexOf('--group') + 1];
+const fileArg  = args[args.indexOf('--file') + 1];
+
+if (groupArg) {
+  group = groupArg; // 'solutions' or 'quick-start'
+} else if (fileArg) {
+  const rel = relative(REPO_ROOT, resolve(fileArg));
+  group = rel.startsWith('solutions/') ? 'solutions'
+        : rel.startsWith('quick-start/') ? 'quick-start'
+        : null;
+  if (!group) {
+    console.error(`Cannot derive group from file path: ${fileArg}`);
+    process.exit(1);
+  }
+} else {
+  console.error('Provide --group solutions|quick-start or --file <path>');
+  process.exit(1);
+}
+
+const groupDir    = join(REPO_ROOT, group);
+const schemaPath  = join(groupDir, 'variables.schema.json');
+const schemaLabel = `${group}/variables.schema.json`;
+
+// ── repo-level config ───────────────────────────────────────────────────────
+
+const configPath = join(REPO_ROOT, '.variable-schema.config.json');
+const repoConfig = existsSync(configPath)
+  ? JSON.parse(readFileSync(configPath, 'utf8'))
+  : { convention: 'camelCase', scope: 'process' };
+
+// Determine scope: arg > schema metadata > repo config
+let scope = scopeArg ?? repoConfig.scope ?? 'process';
+if (existsSync(schemaPath)) {
+  const existing = JSON.parse(readFileSync(schemaPath, 'utf8'));
+  scope = scopeArg ?? existing?.metadata?.scope ?? repoConfig.scope ?? 'process';
+}
+
+// ── extract ─────────────────────────────────────────────────────────────────
+
+const result = await extractGroup(groupDir, scope);
+
+// ── modes ────────────────────────────────────────────────────────────────────
+
+if (mode === 'extract') {
+  const draft = buildDraftSchema(group, result, repoConfig, scope);
+  if (writeFlag) {
+    writeFileSync(schemaPath, JSON.stringify(draft, null, 2) + '\n', 'utf8');
+    console.log(`Wrote ${schemaLabel} (${Object.keys(draft.variables).length} variables)`);
+  } else {
+    console.log(JSON.stringify(draft, null, 2));
+  }
+}
+
+if (mode === 'check') {
+  if (!existsSync(schemaPath)) {
+    console.log(`::warning file=${schemaLabel}::No schema found. Run --extract --write to bootstrap.`);
+    process.exit(0);
+  }
+  const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+  const registered = new Set(Object.keys(schema.variables ?? {}));
+  const deadNames  = new Set(
+    Object.entries(schema.variables ?? {})
+      .filter(([, v]) => v.description?.startsWith('DEAD'))
+      .map(([k]) => k)
+  );
+
+  let exitCode = 0;
+  for (const [name, sources] of result.definitions) {
+    if (!registered.has(name) && !deadNames.has(name)) {
+      const src = sources[0];
+      const file = src?.file ? relative(REPO_ROOT, src.file) : schemaLabel;
+      const lineStr = src?.line ? `,line=${src.line}` : '';
+      console.log(`::error file=${file}${lineStr}::Unregistered variable '${name}' (${sources.map(s => s.kind).join(', ')}). Add it to ${schemaLabel}.`);
+      exitCode = 1;
+    }
+  }
+  process.exit(exitCode);
+}
+
+if (mode === 'dead') {
+  if (!existsSync(schemaPath)) process.exit(0);
+  const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+  const allRefs = new Set([...result.definitions.keys(), ...result.references]);
+
+  for (const [name, entry] of Object.entries(schema.variables ?? {})) {
+    if (entry.description?.startsWith('DEAD')) continue;
+    if (!allRefs.has(name)) {
+      console.log(`::notice::Dead variable candidate in ${group}: '${name}' — not found in any diagram file. Consider prefixing description with 'DEAD - <date>.'`);
+    }
+  }
+  process.exit(0);
+}
+
+// ── extraction ──────────────────────────────────────────────────────────────
+
+/**
+ * @param {string} groupDir  Absolute path to solutions/ or quick-start/
+ * @param {string} scope     'process' | 'all'
+ * @returns {{ definitions: Map<string, Array<{file,line,kind}>>, references: Set<string> }}
+ */
+async function extractGroup(groupDir, scope) {
+  const definitions = new Map(); // name → [{file, line, kind}]
+  const references  = new Set();
+
+  function addDef(name, source) {
+    if (!name || typeof name !== 'string') return;
+    // Take only the root identifier: "loan.amount" → "loan", "toolCallResult.emailSent" → "toolCallResult"
+    name = name.trim().split('.')[0].trim();
+    if (!name || name.includes(' ') || name.startsWith('=')) return;
+    if (!definitions.has(name)) definitions.set(name, []);
+    definitions.get(name).push(source);
+  }
+  function addRef(name) {
+    if (name && typeof name === 'string' && !name.includes(' ')) references.add(name);
+  }
+
+  // BPMN files — exclude target/ and test/ copies
+  for (const file of glob(join(groupDir, '**/*.bpmn')).filter(exclude)) {
+    const { definitions: defs, references: refs } = await parseBpmn(file);
+    for (const { name, line, kind } of defs) addDef(name, { file, line, kind });
+    for (const name of refs) addRef(name);
+  }
+
+  // DMN files
+  for (const file of glob(join(groupDir, '**/*.dmn')).filter(exclude)) {
+    const { definitions: defs } = parseDmn(file);
+    for (const { name, line } of defs) addDef(name, { file, line, kind: 'dmn-output' });
+  }
+
+  // Form files
+  for (const file of glob(join(groupDir, '**/*.form')).filter(exclude)) {
+    const { definitions: defs } = parseForm(file);
+    for (const { name } of defs) addDef(name, { file, line: null, kind: 'form-key' });
+  }
+
+  // CPT test JSON — references only
+  for (const file of glob(join(groupDir, '**/test/src/test/resources/**/*.test.json'))) {
+    const { references: refs } = parseTestJson(file);
+    for (const name of refs) addRef(name);
+  }
+
+  return { definitions, references };
+}
+
+function exclude(f) {
+  return !f.includes('/target/') && !f.includes('/test/src/') && !f.includes('/test/target/');
+}
+
+// ── draft schema builder ────────────────────────────────────────────────────
+
+function buildDraftSchema(group, { definitions }, repoConfig, scope) {
+  const title = group === 'solutions' ? 'Solutions' : 'Quick Start';
+
+  const variables = {};
+  for (const [name, sources] of [...definitions.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const kinds = [...new Set(sources.map(s => s.kind))].join(', ');
+    const processes = [...new Set(sources.map(s => s.file ? relative(REPO_ROOT, s.file).split('/').slice(0, 2).join('/') : group))].join(', ');
+    variables[name] = {
+      title: prettifyName(name),
+      type: 'string',
+      description: `{TODO: business description} — used in: ${processes} (sources: ${kinds})`,
+      examples: ['{TODO: example value}'],
+    };
+  }
+
+  return {
+    $schema: '../schema/process-variables.meta-schema.json',
+    title: `Camunda 8 Tutorials — ${title} Process Variables`,
+    metadata: {
+      convention: repoConfig.convention ?? 'camelCase',
+      scope,
+      owner: `@${process.env.GITHUB_ACTOR ?? 'HanselIdes'}`,
+    },
+    variables,
+  };
+}
+
+function prettifyName(name) {
+  return name
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/^./, s => s.toUpperCase());
+}

--- a/tools/schema/find-similar-variables.mjs
+++ b/tools/schema/find-similar-variables.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * find-similar-variables.mjs — Variable similarity detector.
+ *
+ * Usage:
+ *   node tools/schema/find-similar-variables.mjs
+ *
+ * Loads both group schemas (solutions/ and quick-start/) and runs:
+ *
+ * Signal A — Name similarity (within each group):
+ *   Normalized Levenshtein distance ≤ 0.20 AND shared prefix ≥ 4 chars.
+ *
+ * Signal B — Structural similarity (cross-group):
+ *   Jaccard similarity of `properties` key sets between object-typed variables ≥ 0.50.
+ *   Flags candidates for consolidation into schema/$defs/.
+ *
+ * All output is advisory — exits 0.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve, join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../..');
+
+const GROUPS = ['solutions', 'quick-start'];
+
+// ── load all schemas ─────────────────────────────────────────────────────────
+
+/** @type {Array<{group: string, name: string, entry: object}>} */
+const allVars = [];
+
+for (const group of GROUPS) {
+  const schemaPath = join(REPO_ROOT, group, 'variables.schema.json');
+  if (!existsSync(schemaPath)) continue;
+  const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+
+  for (const [name, entry] of Object.entries(schema.variables || {})) {
+    if (entry.description?.startsWith('DEAD')) continue;
+    allVars.push({ group, name, entry });
+  }
+}
+
+const findings = [];
+
+// ── Signal A: name similarity (within each group) ────────────────────────────
+
+const byGroup = new Map();
+for (const v of allVars) {
+  if (!byGroup.has(v.group)) byGroup.set(v.group, []);
+  byGroup.get(v.group).push(v);
+}
+
+for (const [group, vars] of byGroup) {
+  const threshold = vars.length < 500 ? 0.20 : 0.15;
+
+  for (let i = 0; i < vars.length; i++) {
+    for (let j = i + 1; j < vars.length; j++) {
+      const a = vars[i].name;
+      const b = vars[j].name;
+      const dist = normalizedLevenshtein(a, b);
+      const sharedPrefix = commonPrefixLength(a, b);
+
+      if (dist <= threshold && sharedPrefix >= 4) {
+        findings.push(
+          `**Signal A** (${group}): \`${a}\` and \`${b}\` — name distance ${dist.toFixed(2)}, ${sharedPrefix}-char shared prefix. ` +
+          `May represent the same concept under different names.`
+        );
+      }
+    }
+  }
+}
+
+// ── Signal B: structural similarity (cross-group) ────────────────────────────
+
+const objectVars = allVars.filter(v => v.entry.type === 'object' && v.entry.properties);
+
+for (let i = 0; i < objectVars.length; i++) {
+  for (let j = i + 1; j < objectVars.length; j++) {
+    const a = objectVars[i];
+    const b = objectVars[j];
+
+    const jaccard = jaccardSimilarity(
+      new Set(Object.keys(a.entry.properties)),
+      new Set(Object.keys(b.entry.properties)),
+    );
+
+    if (jaccard >= 0.50) {
+      const sharedProps = Object.keys(a.entry.properties).filter(k => b.entry.properties[k]);
+      const allProps = new Set([...Object.keys(a.entry.properties), ...Object.keys(b.entry.properties)]);
+      const location = a.group === b.group ? a.group : `${a.group} and ${b.group}`;
+      findings.push(
+        `**Signal B** (${location}): \`${a.name}\` and \`${b.name}\` share ${sharedProps.length} of ${allProps.size} sub-properties ` +
+        `(\`${sharedProps.join('`, `')}\`). Jaccard: ${jaccard.toFixed(2)}. ` +
+        `Consider consolidating into \`schema/$defs/\`.`
+      );
+    }
+  }
+}
+
+// ── output ───────────────────────────────────────────────────────────────────
+
+if (findings.length === 0) {
+  console.log('No similar variable pairs found.');
+} else {
+  console.log('## Variable Similarity Report\n');
+  console.log(`Found ${findings.length} similar pair(s). All findings are advisory.\n`);
+  for (const f of findings) console.log(`- ${f}`);
+}
+
+process.exit(0);
+
+// ── algorithms ───────────────────────────────────────────────────────────────
+
+function normalizedLevenshtein(a, b) {
+  const maxLen = Math.max(a.length, b.length);
+  return maxLen === 0 ? 0 : levenshtein(a, b) / maxLen;
+}
+
+function levenshtein(a, b) {
+  const m = a.length, n = b.length;
+  const dp = Array.from({ length: m + 1 }, (_, i) =>
+    Array.from({ length: n + 1 }, (_, j) => i === 0 ? j : j === 0 ? i : 0)
+  );
+  for (let i = 1; i <= m; i++)
+    for (let j = 1; j <= n; j++)
+      dp[i][j] = a[i-1] === b[j-1] ? dp[i-1][j-1] : 1 + Math.min(dp[i-1][j], dp[i][j-1], dp[i-1][j-1]);
+  return dp[m][n];
+}
+
+function commonPrefixLength(a, b) {
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return i;
+}
+
+function jaccardSimilarity(setA, setB) {
+  const intersection = new Set([...setA].filter(x => setB.has(x)));
+  const union = new Set([...setA, ...setB]);
+  return union.size === 0 ? 0 : intersection.size / union.size;
+}

--- a/tools/schema/lib/bpmn.mjs
+++ b/tools/schema/lib/bpmn.mjs
@@ -1,0 +1,93 @@
+/**
+ * bpmn.mjs — BPMN variable extraction using bpmn-moddle + zeebe-bpmn-moddle.
+ *
+ * Definitions (writes):
+ *   zeebe:Output target values
+ *   resultVariable attribute values
+ *
+ * References (reads — keep a variable alive for dead-variable detection):
+ *   zeebe:Input source FEEL expressions (root identifiers)
+ *   Sequence flow conditionExpression bodies (root identifiers)
+ *   Script task / business rule task expression bodies (root identifiers)
+ */
+
+import { createRequire } from 'module';
+import { readFileSync } from 'fs';
+import { feelRootIdents } from './feel.mjs';
+
+const require = createRequire(import.meta.url);
+const { BpmnModdle } = require('bpmn-moddle');
+const ZeebeModdle   = require('zeebe-bpmn-moddle/resources/zeebe.json');
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<{ definitions: Array<{name,line,kind}>, references: Set<string> }>}
+ */
+export async function parseBpmn(filePath) {
+  const xml = readFileSync(filePath, 'utf8');
+  const moddle = new BpmnModdle({ zeebe: ZeebeModdle });
+
+  let rootElement;
+  try {
+    ({ rootElement } = await moddle.fromXML(xml));
+  } catch (err) {
+    console.error(`::warning file=${filePath}::BPMN parse error: ${err.message}`);
+    return { definitions: [], references: new Set() };
+  }
+
+  const definitions = [];
+  const references  = new Set();
+
+  function def(name, kind) {
+    if (name && typeof name === 'string' && !name.includes(' ')) {
+      definitions.push({ name, line: null, kind });
+    }
+  }
+
+  function ref(expr) {
+    for (const ident of feelRootIdents(expr)) references.add(ident);
+  }
+
+  function walk(el) {
+    if (!el || typeof el !== 'object') return;
+
+    switch (el.$type) {
+      case 'zeebe:Output':
+        def(el.target, 'bpmn-output');
+        // source is a read reference
+        if (el.source?.startsWith('=')) ref(el.source);
+        break;
+
+      case 'zeebe:Input':
+        // target is connector config — excluded
+        // source is a read reference if it's a FEEL expression
+        if (el.source?.startsWith('=')) ref(el.source);
+        break;
+
+      case 'bpmn:ServiceTask':
+      case 'bpmn:SendTask':
+      case 'bpmn:BusinessRuleTask':
+      case 'bpmn:ScriptTask':
+        if (el.resultVariable) def(el.resultVariable, 'result-variable');
+        break;
+
+      case 'bpmn:SequenceFlow':
+        if (el.conditionExpression?.body) ref(el.conditionExpression.body);
+        break;
+    }
+
+    // Recurse into all child properties
+    for (const val of Object.values(el)) {
+      if (Array.isArray(val)) {
+        for (const child of val) {
+          if (child && typeof child === 'object' && child.$type) walk(child);
+        }
+      } else if (val && typeof val === 'object' && val.$type) {
+        walk(val);
+      }
+    }
+  }
+
+  walk(rootElement);
+  return { definitions, references };
+}

--- a/tools/schema/lib/dmn.mjs
+++ b/tools/schema/lib/dmn.mjs
@@ -1,0 +1,33 @@
+/**
+ * dmn.mjs — DMN variable extraction via XML regex.
+ *
+ * Definitions (writes):
+ *   <output name="..."> element names — the variable written by this decision's output column.
+ */
+
+import { readFileSync } from 'fs';
+
+/**
+ * @param {string} filePath
+ * @returns {{ definitions: Array<{name, line, kind}> }}
+ */
+export function parseDmn(filePath) {
+  const xml = readFileSync(filePath, 'utf8');
+  const definitions = [];
+  const lines = xml.split('\n');
+
+  // Match <output ... name="varName" ...> on any line
+  const outputPattern = /<output\b[^>]+\bname="([^"]+)"/g;
+  let match;
+  while ((match = outputPattern.exec(xml)) !== null) {
+    const name = match[1];
+    // Find which line this falls on
+    const pos = match.index;
+    const line = xml.slice(0, pos).split('\n').length;
+    if (name && !name.includes(' ')) {
+      definitions.push({ name, line, kind: 'dmn-output' });
+    }
+  }
+
+  return { definitions };
+}

--- a/tools/schema/lib/feel.mjs
+++ b/tools/schema/lib/feel.mjs
@@ -1,0 +1,51 @@
+/**
+ * feel.mjs — Regex-based FEEL expression root identifier extractor.
+ *
+ * Extracts the root variable references from a FEEL expression.
+ * "Root" means the first identifier in a path expression — the process variable name.
+ *
+ * Example: "=if currentEmail.plainTextBody != null then currentEmail.plainTextBody else currentEmail.htmlBody"
+ * → ["currentEmail"]
+ *
+ * Limitation: only captures the first identifier per path. Multi-variable expressions like
+ * "=a + b" produce ["a"] not ["a","b"]. This is sufficient for dead variable detection
+ * (any appearance keeps a variable alive) but not for exhaustive reference analysis.
+ * Upgrade path: replace with feelin's getVariableReferences().
+ */
+
+const FEEL_KEYWORDS = new Set([
+  'if', 'then', 'else', 'and', 'or', 'not', 'true', 'false', 'null',
+  'instance', 'of', 'in', 'some', 'every', 'satisfies', 'return',
+  'function', 'external', 'for', 'between', 'context', 'list', 'filter',
+  'duration', 'date', 'time', 'string', 'number', 'boolean',
+]);
+
+/**
+ * @param {string} expr — A FEEL expression, optionally prefixed with '='.
+ * @returns {Set<string>} Root variable identifiers referenced in the expression.
+ */
+export function feelRootIdents(expr) {
+  if (!expr || typeof expr !== 'string') return new Set();
+
+  // Strip leading '=' or whitespace
+  let src = expr.replace(/^[=\s]+/, '');
+
+  // Remove string literals to avoid false matches on quoted identifiers
+  src = src.replace(/"[^"]*"/g, '""');
+  src = src.replace(/'[^']*'/g, "''");
+
+  const results = new Set();
+
+  // Match path expressions: identifier optionally followed by .property or [index]
+  // We only want the root — the first identifier segment
+  const pathPattern = /\b([a-zA-Z_][a-zA-Z0-9_]*)(?:\s*[.[)])?/g;
+  let match;
+  while ((match = pathPattern.exec(src)) !== null) {
+    const ident = match[1];
+    if (!FEEL_KEYWORDS.has(ident) && !/^\d/.test(ident)) {
+      results.add(ident);
+    }
+  }
+
+  return results;
+}

--- a/tools/schema/lib/form.mjs
+++ b/tools/schema/lib/form.mjs
@@ -1,0 +1,50 @@
+/**
+ * form.mjs — Camunda Form variable extraction.
+ *
+ * Definitions (writes):
+ *   All `key` values on form components at any nesting depth.
+ *   Form keys bind to process variables when the user task submits.
+ */
+
+import { readFileSync } from 'fs';
+
+/**
+ * @param {string} filePath
+ * @returns {{ definitions: Array<{name, line, kind}> }}
+ */
+export function parseForm(filePath) {
+  let form;
+  try {
+    form = JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    console.error(`::warning file=${filePath}::Form parse error: ${err.message}`);
+    return { definitions: [] };
+  }
+
+  const definitions = [];
+
+  function walk(components) {
+    if (!Array.isArray(components)) return;
+    for (const component of components) {
+      if (component.key && typeof component.key === 'string' && !component.key.includes(' ')) {
+        definitions.push({ name: component.key, line: null, kind: 'form-key' });
+      }
+      if (component.components) walk(component.components);
+      // Some form layouts nest inside rows/columns
+      if (component.rows) {
+        for (const row of component.rows) {
+          if (Array.isArray(row)) walk(row);
+          else if (row.columns) walk(row.columns);
+        }
+      }
+      if (component.columns) {
+        for (const col of component.columns) {
+          if (col.components) walk(col.components);
+        }
+      }
+    }
+  }
+
+  walk(form.components);
+  return { definitions };
+}

--- a/tools/schema/lib/glob.mjs
+++ b/tools/schema/lib/glob.mjs
@@ -1,0 +1,68 @@
+/**
+ * glob.mjs — Minimal synchronous glob using Node.js built-ins.
+ * Supports ** wildcards. All paths must be absolute.
+ */
+
+import { readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Returns all absolute file paths matching one or more glob patterns.
+ * @param {...string} patterns  Absolute glob patterns.
+ * @returns {string[]}
+ */
+export function glob(...patterns) {
+  const results = new Set();
+  for (const pattern of patterns) {
+    for (const f of matchPattern(pattern)) results.add(f);
+  }
+  return [...results].sort();
+}
+
+/**
+ * Match a single glob pattern.
+ * Handles ** by walking the directory tree from the non-wildcard prefix,
+ * then filtering each file path against a regex built from the full pattern.
+ */
+function matchPattern(pattern) {
+  // Find the deepest directory prefix that contains no wildcards
+  const parts = pattern.split('/');
+  const staticParts = [];
+  for (const part of parts) {
+    if (part.includes('*')) break;
+    staticParts.push(part);
+  }
+  const baseDir = staticParts.join('/') || '/';
+
+  if (!existsSync(baseDir)) return [];
+
+  // Convert the glob pattern to a regular expression:
+  // Process wildcards BEFORE escaping so they don't get caught by the escaper.
+  const regexSrc = pattern
+    .split('**').join('\x00DSTAR\x00')      // protect ** with placeholder
+    .split('*').join('\x00STAR\x00')        // protect * with placeholder
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')  // escape regex special chars
+    .split('\x00DSTAR\x00').join('.*')      // ** → match any path (including /)
+    .split('\x00STAR\x00').join('[^/]*');   // * → match any non-separator sequence
+
+  const regex = new RegExp('^' + regexSrc + '$');
+
+  return walkDir(baseDir).filter(f => regex.test(f));
+}
+
+function walkDir(dir) {
+  const results = [];
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...walkDir(full));
+      } else if (entry.isFile()) {
+        results.push(full);
+      }
+    }
+  } catch {
+    // skip unreadable dirs
+  }
+  return results;
+}

--- a/tools/schema/lib/test-json.mjs
+++ b/tools/schema/lib/test-json.mjs
@@ -1,0 +1,44 @@
+/**
+ * test-json.mjs — CPT test JSON variable reference extraction.
+ *
+ * References (reads — keep variables alive for dead detection):
+ *   All keys from `variables` objects in any instruction step.
+ *
+ * CPT test files use variables as inputs to instructions and assertions.
+ * Their presence confirms the variable is known to the process.
+ */
+
+import { readFileSync } from 'fs';
+
+/**
+ * @param {string} filePath
+ * @returns {{ references: Set<string> }}
+ */
+export function parseTestJson(filePath) {
+  let data;
+  try {
+    data = JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    console.error(`::warning file=${filePath}::Test JSON parse error: ${err.message}`);
+    return { references: new Set() };
+  }
+
+  const references = new Set();
+
+  function collect(obj) {
+    if (!obj || typeof obj !== 'object') return;
+    if (Array.isArray(obj)) {
+      for (const item of obj) collect(item);
+      return;
+    }
+    if ('variables' in obj && obj.variables && typeof obj.variables === 'object') {
+      for (const key of Object.keys(obj.variables)) {
+        if (key && !key.includes(' ')) references.add(key);
+      }
+    }
+    for (const val of Object.values(obj)) collect(val);
+  }
+
+  collect(data);
+  return { references };
+}

--- a/tools/schema/lint-naming.mjs
+++ b/tools/schema/lint-naming.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * lint-naming.mjs — Naming convention linter for process variable schemas.
+ *
+ * Usage:
+ *   node tools/schema/lint-naming.mjs --group solutions
+ *   node tools/schema/lint-naming.mjs --group quick-start
+ *
+ * Reads the repo-level .variable-schema.config.json for the expected convention.
+ * Per-schema metadata.convention overrides the repo default.
+ *
+ * Emits GitHub Actions annotations for each violation.
+ * Exits 1 if enforceNaming is true and violations found; otherwise exits 0.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve, join, relative, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname  = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT  = resolve(__dirname, '../..');
+
+const args     = process.argv.slice(2);
+const groupArg = args[args.indexOf('--group') + 1];
+
+if (!groupArg) {
+  console.error('Usage: lint-naming.mjs --group solutions|quick-start');
+  process.exit(1);
+}
+
+const schemaPath = join(REPO_ROOT, groupArg, 'variables.schema.json');
+
+const configPath = join(REPO_ROOT, '.variable-schema.config.json');
+const repoConfig = existsSync(configPath)
+  ? JSON.parse(readFileSync(configPath, 'utf8'))
+  : { convention: 'camelCase', enforceNaming: true };
+
+// When enforceNaming is false, emit notices but don't fail CI.
+// Set to true after the snake_case migration PR (issue #96) lands.
+const enforce = repoConfig.enforceNaming !== false;
+
+let exitCode = 0;
+
+if (!existsSync(schemaPath)) {
+  console.log(`::notice::No schema found at ${relative(REPO_ROOT, schemaPath)} — skipping naming lint.`);
+  process.exit(0);
+}
+
+const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+const convention = schema.metadata?.convention ?? repoConfig.convention ?? 'camelCase';
+const schemaFile = relative(REPO_ROOT, schemaPath);
+
+for (const [name, entry] of Object.entries(schema.variables || {})) {
+  if (entry.description?.startsWith('DEAD')) continue;
+
+  const violation = checkConvention(name, convention);
+  if (violation) {
+    const suggested = toConvention(name, convention);
+    const level = enforce ? 'error' : 'notice';
+    console.log(`::${level} file=${schemaFile}::Naming violation: '${name}' does not follow ${convention}. Suggested: '${suggested}'. ${violation}`);
+    if (enforce) exitCode = 1;
+  }
+}
+
+process.exit(exitCode);
+
+// ── convention checkers ─────────────────────────────────────────────────────
+
+function checkConvention(name, convention) {
+  if (!name) return null;
+  switch (convention) {
+    case 'camelCase':
+      if (!/^[a-z][a-zA-Z0-9]*$/.test(name)) {
+        if (name.includes('_')) return 'Contains underscore — use camelCase.';
+        if (/^[A-Z]/.test(name)) return 'Starts with uppercase — use camelCase (lowercase first letter).';
+        return 'Does not match camelCase pattern.';
+      }
+      return null;
+    case 'snake_case':
+      if (!/^[a-z][a-z0-9_]*$/.test(name) || /[A-Z]/.test(name))
+        return 'Does not match snake_case pattern (lowercase, underscores only).';
+      return null;
+    case 'PascalCase':
+      if (!/^[A-Z][a-zA-Z0-9]*$/.test(name))
+        return 'Does not match PascalCase pattern (uppercase first letter, no underscores).';
+      return null;
+    default:
+      return null;
+  }
+}
+
+function toConvention(name, convention) {
+  const words = name
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .split(/[_\s]+/)
+    .filter(Boolean);
+
+  switch (convention) {
+    case 'camelCase':
+      return words.map((w, i) => i === 0 ? w.toLowerCase() : w[0].toUpperCase() + w.slice(1).toLowerCase()).join('');
+    case 'snake_case':
+      return words.map(w => w.toLowerCase()).join('_');
+    case 'PascalCase':
+      return words.map(w => w[0].toUpperCase() + w.slice(1).toLowerCase()).join('');
+    default:
+      return name;
+  }
+}


### PR DESCRIPTION
Closes #95

## Summary

- Two group-level schemas cover all processes: `solutions/variables.schema.json` (114 variables) and `quick-start/variables.schema.json` (1 variable)
- Both validate against `schema/process-variables.meta-schema.json`
- Variables with the same name across multiple processes within a group share a single entry — the schema is a vocabulary, not a per-process inventory
- Dotted form key bindings (e.g. `loan.amount`) are resolved to their root variable (`loan`)

## Toolchain (`tools/schema/`)

| Script | Purpose |
|--------|---------|
| `extract-variables.mjs` | `--extract` bootstraps a schema; `--check` fails CI on unregistered variables; `--dead` flags candidates for DEAD marking |
| `lint-naming.mjs` | Enforces camelCase convention; gated by `enforceNaming: false` in config until issue #96 (snake_case migration) lands |
| `find-similar-variables.mjs` | Signal A: Levenshtein name similarity within group. Signal B: Jaccard property-set overlap cross-group. Advisory only. |

## CI (`.github/workflows/variable-schema.yml`)

Triggers on changes to BPMN, DMN, form, test JSON, or schema files. Detects which group changed and runs: validate meta-schema → check unregistered variables → lint naming. Dead scan and similarity run as advisory jobs after check passes. A cascade warning posts to the job summary when `schema/` itself changes.

## Test plan

- [ ] `node tools/schema/extract-variables.mjs --check --group solutions` exits 0
- [ ] `node tools/schema/extract-variables.mjs --check --group quick-start` exits 0
- [ ] `node tools/schema/lint-naming.mjs --group solutions` exits 0 (notices for 29 snake_case variables, no errors while `enforceNaming: false`)
- [ ] `node tools/schema/find-similar-variables.mjs` exits 0 with advisory output
- [ ] Adding a new BPMN output target without a schema entry causes `--check` to exit 1 with a GitHub annotation
- [ ] Issue #96 (snake_case migration) is a prerequisite before setting `enforceNaming: true`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)