### PR TITLE
docs(claude-md): codify schema URL, examples depth, and BPMN conflict pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Both point `$schema` at the absolute URL: `https://raw.githubusercontent.com/cam
 
 The schema system is described in full in GitHub issue #95. Claude maintains it autonomously:
 
-- **Add a new process variable:** add it to the appropriate group schema with `title`, `type`, `description`, and `examples`. For object variables add `properties`. `examples` is required at every nesting level — every entry with a `type` field must carry `examples`, including nested object `properties`.
+- **Add a new process variable:** add it to the appropriate group schema with `title`, `type`, `description`, and `examples`. For object variables add `properties`. `examples` is required at every nesting level: every entry with a `type` field must carry `examples`, including nested object `properties`.
 - **Check on PR:** run `--check --group solutions|quick-start` and `--dead --group solutions|quick-start`; fix unregistered variable errors; post dead-variable candidates as PR comments.
 - **Naming violations:** fix in BPMN output targets, DMN outputs, form keys, and test JSON in one commit (order: form keys → BPMN → DMN → test JSON). Update the schema entry name to match.
 - **Structural similarity:** run `node tools/schema/find-similar-variables.mjs`; evaluate whether cross-group consolidation into `schema/$defs/` is warranted at Jaccard ≥ 0.70.
@@ -37,7 +37,7 @@ The schema system is described in full in GitHub issue #95. Claude maintains it 
 ## BPMN and process changes
 
 - Run `npx bpmnlint --config .bpmnlintrc <file>` after every BPMN edit; fix all errors before committing.
-- When resolving a merge conflict on a lint-fix PR, run `git checkout origin/main -- <file>` then `npm run lint` to confirm the main version already carries the fix. If lint passes, the conflict is resolved — don't attempt a manual 3-way merge of BPMN XML.
+- When resolving a merge conflict on a lint-fix PR, run `git checkout origin/main -- <file>` then `npm run lint` to confirm the main version already carries the fix. If lint passes, the conflict is resolved; don't attempt a manual 3-way merge of BPMN XML.
 - Do not rename BPMN element `id` attributes — they break test references.
 - Only propose `name` attribute changes and test JSON updates.
 - After fixing BPMN names, open in Camunda Modeler: `open -a "Camunda Modeler" <file>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,11 @@ There are two group-level schemas, each covering all processes in their group:
 - `solutions/variables.schema.json` — vocabulary for all solution processes
 - `quick-start/variables.schema.json` — vocabulary for all quick-start processes
 
-Both point `$schema` at `../schema/process-variables.meta-schema.json`.
+Both point `$schema` at the absolute URL: `https://raw.githubusercontent.com/camunda/camunda-8-tutorials/main/schema/process-variables.meta-schema.json`
 
 The schema system is described in full in GitHub issue #95. Claude maintains it autonomously:
 
-- **Add a new process variable:** add it to the appropriate group schema with `title`, `type`, `description`, and `examples`. For object variables add `properties`.
+- **Add a new process variable:** add it to the appropriate group schema with `title`, `type`, `description`, and `examples`. For object variables add `properties`. `examples` is required at every nesting level — every entry with a `type` field must carry `examples`, including nested object `properties`.
 - **Check on PR:** run `--check --group solutions|quick-start` and `--dead --group solutions|quick-start`; fix unregistered variable errors; post dead-variable candidates as PR comments.
 - **Naming violations:** fix in BPMN output targets, DMN outputs, form keys, and test JSON in one commit (order: form keys → BPMN → DMN → test JSON). Update the schema entry name to match.
 - **Structural similarity:** run `node tools/schema/find-similar-variables.mjs`; evaluate whether cross-group consolidation into `schema/$defs/` is warranted at Jaccard ≥ 0.70.
@@ -37,6 +37,7 @@ The schema system is described in full in GitHub issue #95. Claude maintains it 
 ## BPMN and process changes
 
 - Run `npx bpmnlint --config .bpmnlintrc <file>` after every BPMN edit; fix all errors before committing.
+- When resolving a merge conflict on a lint-fix PR, run `git checkout origin/main -- <file>` then `npm run lint` to confirm the main version already carries the fix. If lint passes, the conflict is resolved — don't attempt a manual 3-way merge of BPMN XML.
 - Do not rename BPMN element `id` attributes — they break test references.
 - Only propose `name` attribute changes and test JSON updates.
 - After fixing BPMN names, open in Camunda Modeler: `open -a "Camunda Modeler" <file>`.


### PR DESCRIPTION
## What changed

- Fixed `$schema` reference: absolute GitHub raw URL replaces the relative path (which violated the meta-schema's `const` constraint)
- Clarified `examples` depth requirement: required at every nesting level, not just top-level entries
- Added BPMN merge conflict pattern: `git checkout origin/main -- <file>` + lint verify is safer than manual 3-way merge of BPMN XML

## Why

All three rules were codified from PR #97 and #98 failures. Without them, the same mistakes (wrong `$schema` path, missing nested `examples`, broken BPMN merge) would recur on the next similar task.

## Notes for reviewer

Pre-existing rule about `id` attribute em-dash on line 41 not touched — it was there before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)